### PR TITLE
feat: dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,17 +68,30 @@
   position: relative; 
 }
 .modal-actions {
-  background: #fff; 
-  position: sticky; 
-  bottom: 0; 
-  padding-bottom: 1rem; 
+  background: #fff;
+  position: sticky;
+  bottom: 0;
+  padding-bottom: 1rem;
   margin-bottom: 0;
 }
+/* Dark mode styles */
+body.dark { background: #1e1e1e; color: #eee; }
+body.dark header { background: #333; }
+body.dark nav { background: #2b2b2b; }
+body.dark nav button { background: #2b2b2b; color: #eee; }
+body.dark nav button.active { background: #3a3a3a; }
+body.dark table { background: #2b2b2b; color: #eee; }
+body.dark th { background: #3a3a3a; }
+body.dark td { border-color: #555; }
+body.dark .card { background: #2b2b2b; box-shadow: 0 2px 8px #0005; }
+body.dark .modal { background: #2b2b2b; color: #eee; }
+body.dark .log-table th { background: #3a3a3a; }
   </style>
 </head>
 <body>
   <header>
     <h1>Partner-Dashboard v4.5</h1>
+    <button id="darkModeToggle" class="export-btn" style="background:#555;margin-left:1rem;">Dark Mode</button>
     <div class="file-upload">
       <input type="file" id="csvFile" accept=".csv" />
       <label for="csvFile">Partnerdaten als CSV importieren</label>
@@ -235,7 +248,16 @@ function renderAll() {
   renderTable();
   renderCards();
 }
-window.onload = () => document.getElementById('demoDataBtn').click();
+window.onload = () => {
+  if (localStorage.getItem('prefers-dark') === 'true') {
+    document.body.classList.add('dark');
+  }
+  document.getElementById('darkModeToggle').onclick = () => {
+    document.body.classList.toggle('dark');
+    localStorage.setItem('prefers-dark', document.body.classList.contains('dark'));
+  };
+  document.getElementById('demoDataBtn').click();
+};
 
 // === UI MESSAGES ===
 function showMsg(txt, type="success") {

--- a/main.js
+++ b/main.js
@@ -1,1 +1,16 @@
-js\nconst {app, BrowserWindow} = require('electron');\nconst path = require('path');\n\nfunction create () {\n const win = new BrowserWindow({width:1200, height:800});\n win.loadFile(path.join(__dirname, 'index.html'));\n}\n\napp.whenReady().then(create);\napp.on('window-all-closed', () => app.quit());\n
+const {app, BrowserWindow} = require('electron');
+const path = require('path');
+
+function create () {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(create);
+app.on('window-all-closed', () => app.quit());


### PR DESCRIPTION
## Summary
- add a dark mode toggle in the dashboard
- include dark mode styles and persistence
- configure Electron to use a preload script

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c3bbadba8832fa8308173cb3649e8