### PR TITLE
Add backlog CSV and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENT INSTRUCTIONS
+
+## Scope
+This file applies to the entire repository.
+
+## Programmatic Checks
+No automated tests are currently defined. Before committing, ensure that `BACKLOG.csv` is kept in CSV format.
+
+## Contribution Guidelines
+- Record progress for each coding session in `BACKLOG.csv` by adding a new column per session or by updating status fields. Keep the original epics and tasks intact.
+- Write commits in English.

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -1,0 +1,29 @@
+EPIC,User Story (Akzeptanzkriterien),Kern-Tasks
+E1 · Robustes CSV-Handling,"Als Admin möchte ich beliebige Partner-CSV-Dateien mit ≥ 30 Spalten laden, damit ich sie ohne Vorarbeit in der App ansehen kann.","1. Header-Validierung gegen Referenz-Schema (fehlende/unerwartete Spalten kennzeichnen)
+2. Fallback-Mapping (Alias-Namen wie ‚Vertragsbeginn‘/‚Contract_Start‘ erkennen)
+3. Graceful Parsing (UTF-8 +BOM, Semikolon oder Komma, Quotes, Umlaut-Handling)
+4. Leere Felder normalisieren ("")"
+E2 · Skalierbare Tabellen-UI,"Als Benutzer möchte ich alle Spalten horizontal scrollen können und per Spalten-Menü Spalten ein/ausblenden, damit die Ansicht übersichtlich bleibt.","1. Sticky Header + X-Scrollbar (Tailwind-Klassen anpassen)
+2. Toggle-Menü mit Checkboxen → display:none auf <th>/<td>
+3. Persistente Sichtbarkeits-Prefs (localStorage)"
+E3 · Erweiterte Filter + Suche,"Als Analyst will ich jede beliebige Spalte filtern (Text, Range, Dropdown), um gezielt Datensätze zu finden.","1. Dynamische Filter-Komponente pro Spalte (Typ-Erkennung)
+2. Debounced Volltext-Suche über alle Spalten
+3. Gespeicherte Filter-Presets"
+E4 · Bearbeiten & Änderungsprotokoll,"Als Power-User will ich Datensätze inline oder via Modal bearbeiten und die Änderungen als CSV exportieren.","1. Erweiterung des Modal-Editors auf alle Felder (scrollbar)
+2. Undo-/Redo-Stack im changelog-Array
+3. Export ‚partner_export.csv‘ mit gleicher Spaltenreihenfolge"
+E5 · Leistungsfähige Visualisierung,"Als Manager möchte ich auch bei >1000 Zeilen KPI-Boxen und Diagramme ohne Wartezeit sehen.","1. Daten-Aggregation im Web Worker
+2. Lazy Rendering der Chart.js-Plots (IntersectionObserver)
+3. Optionale Paginierung / Virtual Scrolling in Tabelle"
+E6 · Packaging & Distribution,"Als Entwickler will ich mit einem Befehl eine signierte Windows-Installer-EXE erzeugen.","1. Electron-Builder Konfig (NSIS, Icon, Auto-Update off)
+2. npm run build:win-Script
+3. GitHub Actions CI-Workflow"
+E7 · Demo- & Test-Daten,"Als QA will ich mehrere Beispiel-CSV-Dateien mit Voll-Schema haben, um UI-Regressionen zu testen.","1. partner_full.csv (36 Spalten × ≥ 50 Zeilen, realistische Daten)
+2. partner_edge.csv (Extremwerte, lange URLs, Umlaut-Mix, leere Felder)
+3. Download-Knopf ‚Demo-CSV auswählen‘ im Header"
+E8 · Dokumentation & Onboarding,"Als neuer Mitarbeiter möchte ich in 5 Minuten verstehen, wie ich die App starte, baue und verteile.","1. README-Abschnitt ‚CSV-Schema v1.0 (Tabelle)‘
+2. GIF oder Screenshot-Tour
+3. Troubleshooting-Abschnitt (häufige CSV-Fehler)"
+E9 · Qualität & Automatisierung,"Als Maintainer möchte ich sicherstellen, dass Grundfunktionen nach jedem Commit laufen.","1. Headless Electron-Smoke-Test (Playwright) lädt partner_full.csv
+2. ESLint + Prettier Hook
+3. Dependabot für npm-Updates"


### PR DESCRIPTION
## Summary
- add backlog with epics and core tasks
- add repo-wide AGENT instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68500f1fb0f4832fbbf07733980a73d6