### PR TITLE
feat(e11): add column view presets (table dropdown)

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -28,3 +28,4 @@ EPIC,User Story (Akzeptanzkriterien),Kern-Tasks,Status
 2. ESLint + Prettier Hook
 3. Dependabot für npm-Updates","done (2025-06-17)"
 "E10 · Portable Win-Build","Als Entwickler möchte ich eine portable Win32-EXE erzeugen, die ohne Installer läuft.","1. electron-builder portable config, 2. build:win32 script, 3. Workflow upload","done (2025-06-17)"
+"E11 · Tabellen-Preset-Dropdown","Als Nutzer*in möchte ich per Dropdown zwischen vordefinierten Spalten-Ansichten umschalten können (Alle | Vertrag | Tech | Onboarding | Marketing), damit die Tabelle lesbar bleibt, ohne vertikalen Text.","1. Dropdown für Spaltenansicht 2. columnViews Objekt 3. Change-Event blendet Spalten aus","done"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ komplexe Build-Kette oder Cloud-Abhängigkeiten.
 | Sofort-Suche & Zeilenfilter |
 | Dark-/Light-Umstellung (Tailwind) |
 | Undo-/Redo-Stack (max. 5 Schritte) |
+| Spalten-Ansichten (Alle/Vertrag/Tech/Onboarding/Marketing) |
 | 100 % offline, keine Install/Rights nötig |
 
 > *Roadmap:* XLSX-Export · KPI-Tiles · Drag-&-Drop-Upload · Karten-Ansicht  

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <link rel="stylesheet" href="styles.css">
   <style>
     body { font-family: Arial, sans-serif; margin: 0; background: #f9f9fb;}
     header { background: #222; color: #fff; padding: 1rem; text-align: center;}
@@ -122,6 +123,13 @@ body.dark .log-table th { background: #3a3a3a; }
     <section id="table">
       <div class="search-filter" id="filters"></div>
       <div style="position:relative;margin-bottom:.5rem;">
+        <select id="viewSelect" style="margin-right:.5rem;">
+          <option value="Alle">Alle</option>
+          <option value="Vertrag">Vertrag</option>
+          <option value="Tech">Tech</option>
+          <option value="Onboarding">Onboarding</option>
+          <option value="Marketing">Marketing</option>
+        </select>
         <button id="columnBtn" class="export-btn" style="background:#777;margin-right:.5rem;">Spalten</button>
         <div id="columnMenu" class="column-menu"></div>
       </div>
@@ -216,14 +224,32 @@ let changeIndex = 0;
 let charts = {};
 let chartWorker = new Worker('chartWorker.js');
 let hiddenColumns = JSON.parse(localStorage.getItem('hiddenColumns')||'[]');
+const columnViews = {
+  Alle: [],
+  Vertrag:["Partnername","Systemname","Vertragstyp","Vertragsstatus","Vertragsbeginn","Vertragsende","Kündigungsfrist"],
+  Tech:["Partnername","Systemname","Schnittstelle","Format","API URL","Schnittstellenstatus","Developer_Portal_Zugang"],
+  Onboarding:["Partnername","Systemname","Trainingsstatus","Schulungstypen","Schulungsunterlagen","Webinar_Termine"],
+  Marketing:["Partnername","Systemname","Branche","Landingpage","Marketingkampagne","Produktflyer_URL","Präsentation_URL"]
+};
 let currentPage = 1;
 const rowsPerPage = 20;
+
+function getVisibleColumns(){
+  return csvHeaders.filter(h=>!hiddenColumns.includes(h));
+}
 
 function debounce(fn, wait=300) {
   let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), wait); };
 }
 
 let editableFields = [];
+
+function applyView(name){
+  const cols = columnViews[name] || csvHeaders;
+  hiddenColumns = csvHeaders.filter(h=>!cols.includes(h));
+  localStorage.setItem('hiddenColumns', JSON.stringify(hiddenColumns));
+  renderTable();
+}
 
 // === TAB NAVIGATION ===
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -328,6 +354,9 @@ window.onload = () => {
   document.getElementById('columnBtn').onclick = () => {
     const menu = document.getElementById('columnMenu');
     menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+  };
+  document.getElementById('viewSelect').onchange = function(){
+    applyView(this.value);
   };
   document.getElementById('prevPage').onclick = ()=>{ if(currentPage>1){ currentPage--; renderTable(); }};
   document.getElementById('nextPage').onclick = ()=>{ currentPage++; renderTable(); };
@@ -448,9 +477,10 @@ function savePreset(){
 }
 function getFilteredData(){
   const search=(document.getElementById('searchInput')?.value||'').toLowerCase();
+  const headers=getVisibleColumns();
   return partnerData.filter(r=>{
     if(search && !Object.values(r).some(v=>String(v||'').toLowerCase().includes(search))) return false;
-    for(const h of csvHeaders){
+    for(const h of headers){
       const type=detectType(h);
       if(type==='select'){
         const val=document.getElementById(`filter_${h}`)?.value;
@@ -494,14 +524,14 @@ function renderTable() {
     document.getElementById("partnerTable").querySelector("tbody").innerHTML = "";
     return;
   }
-  let ths = csvHeaders.map((h,i)=>`<th data-col="${i}" ${hiddenColumns.includes(h)?'style="display:none"':''}>${h}</th>`).join("") + "<th>Aktion</th>";
+  let ths = csvHeaders.map(h=>`<th data-col="${h}" class="${hiddenColumns.includes(h)?'hidden':''}">${h}</th>`).join("") + "<th>Aktion</th>";
   document.getElementById("partnerTable").querySelector("thead").innerHTML = `<tr>${ths}</tr>`;
   const filtered = getFilteredData();
   const totalPages = Math.max(1, Math.ceil(filtered.length / rowsPerPage));
   if(currentPage>totalPages) currentPage = totalPages;
   let rows = "";
   filtered.slice((currentPage-1)*rowsPerPage, currentPage*rowsPerPage).forEach((row,idx) => {
-    let tds = csvHeaders.map((h,i)=>`<td data-col="${i}" ${hiddenColumns.includes(h)?'style="display:none"':''}>${row[h]||""}</td>`).join("");
+    let tds = csvHeaders.map(h=>`<td data-col="${h}" class="${hiddenColumns.includes(h)?'hidden':''}">${row[h]||""}</td>`).join("");
     tds += `<td><button class="edit-btn" onclick="openEditor(${partnerData.indexOf(row)})">Edit</button></td>`;
     rows += `<tr>${tds}</tr>`;
   });
@@ -612,9 +642,10 @@ window.redoChange = function(){
 
 // === CSV EXPORT ===
 window.exportTableCSV = function() {
-  const rows = [csvHeaders];
+  const headers = getVisibleColumns();
+  const rows = [headers];
   getFilteredData().forEach(r => {
-    rows.push(csvHeaders.map(h => r[h]||""));
+    rows.push(headers.map(h => r[h]||""));
   });
   const csv = Papa.unparse(rows);
   const blob = new Blob([csv],{type:"text/csv"});

--- a/main.js
+++ b/main.js
@@ -1,6 +1,14 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
+const columnViews = {
+  Alle: [],
+  Vertrag:["Partnername","Systemname","Vertragstyp","Vertragsstatus","Vertragsbeginn","Vertragsende","Kündigungsfrist"],
+  Tech:["Partnername","Systemname","Schnittstelle","Format","API URL","Schnittstellenstatus","Developer_Portal_Zugang"],
+  Onboarding:["Partnername","Systemname","Trainingsstatus","Schulungstypen","Schulungsunterlagen","Webinar_Termine"],
+  Marketing:["Partnername","Systemname","Branche","Landingpage","Marketingkampagne","Produktflyer_URL","Präsentation_URL"]
+};
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 1200,

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,2 @@
+.hidden{display:none}
+@media(max-width:600px){#viewSelect{width:100%;margin-bottom:.5rem}}


### PR DESCRIPTION
## Summary
- add dropdown for column view presets
- support column preset logic and hide columns with `.hidden`
- respect visible columns in filter and export
- document new feature
- track progress in backlog

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68512cb8de34832fb2d2680202aeb89a