### PR TITLE
Implement version bump, menu enhancements and new chart

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -1,33 +1,33 @@
-EPIC,User Story (Akzeptanzkriterien),Kern-Tasks,Status,2025-06-17
-"E1 · Robustes CSV-Handling","Als Admin möchte ich beliebige Partner-CSV-Dateien mit ≥ 30 Spalten laden, damit ich sie ohne Vorarbeit in der App ansehen kann.","1. Header-Validierung gegen Referenz-Schema (fehlende/unerwartete Spalten kennzeichnen)
-2. Fallback-Mapping (Alias-Namen wie ‚Vertragsbeginn‘/‚Contract_Start‘ erkennen)
-3. Graceful Parsing (UTF-8 +BOM, Semikolon oder Komma, Quotes, Umlaut-Handling)
-4. Leere Felder normalisieren ("")","done"
-"E2 · Skalierbare Tabellen-UI","Als Benutzer möchte ich alle Spalten horizontal scrollen können und per Spalten-Menü Spalten ein/ausblenden, damit die Ansicht übersichtlich bleibt.","1. Sticky Header + X-Scrollbar (Tailwind-Klassen anpassen)
-2. Toggle-Menü mit Checkboxen → display:none auf <th>/<td>
-3. Persistente Sichtbarkeits-Prefs (localStorage)","done (2025-06-18)"
-"E3 · Erweiterte Filter + Suche","Als Analyst will ich jede beliebige Spalte filtern (Text, Range, Dropdown), um gezielt Datensätze zu finden.","1. Dynamische Filter-Komponente pro Spalte (Typ-Erkennung)
-2. Debounced Volltext-Suche über alle Spalten
-3. Gespeicherte Filter-Presets","done"
-"E4 · Bearbeiten & Änderungsprotokoll","Als Power-User will ich Datensätze inline oder via Modal bearbeiten und die Änderungen als CSV exportieren.","1. Erweiterung des Modal-Editors auf alle Felder (scrollbar)
-2. Undo-/Redo-Stack im changelog-Array
-3. Export ‚partner_export.csv‘ mit gleicher Spaltenreihenfolge","done"
-"E5 · Leistungsfähige Visualisierung","Als Manager möchte ich auch bei >1000 Zeilen KPI-Boxen und Diagramme ohne Wartezeit sehen.","1. Daten-Aggregation im Web Worker
-2. Lazy Rendering der Chart.js-Plots (IntersectionObserver)
-3. Optionale Paginierung / Virtual Scrolling in Tabelle","done"
-"E6 · Packaging & Distribution","Als Entwickler will ich mit einem Befehl eine signierte Windows-Installer-EXE erzeugen.","1. Electron-Builder Konfig (NSIS, Icon, Auto-Update off)
-2. npm run build:win-Script
-3. GitHub Actions CI-Workflow","done"
-"E7 · Demo- & Test-Daten","Als QA will ich mehrere Beispiel-CSV-Dateien mit Voll-Schema haben, um UI-Regressionen zu testen.","1. partner_full.csv (36 Spalten × ≥ 50 Zeilen, realistische Daten)
-2. partner_edge.csv (Extremwerte, lange URLs, Umlaut-Mix, leere Felder)
-3. Download-Knopf ‚Demo-CSV auswählen‘ im Header","done (2025-06-17)"
-"E8 · Dokumentation & Onboarding","Als neuer Mitarbeiter möchte ich in 5 Minuten verstehen, wie ich die App starte, baue und verteile.","1. README-Abschnitt ‚CSV-Schema v1.0 (Tabelle)‘
-2. GIF oder Screenshot-Tour
-3. Troubleshooting-Abschnitt (häufige CSV-Fehler)","done (2025-06-17)"
-"E9 · Qualität & Automatisierung","Als Maintainer möchte ich sicherstellen, dass Grundfunktionen nach jedem Commit laufen.","1. Headless Electron-Smoke-Test (Playwright) lädt partner_full.csv
-2. ESLint + Prettier Hook
-3. Dependabot für npm-Updates","done (2025-06-17)"
-"E10 · Portable Win-Build","Als Entwickler möchte ich eine portable Win32-EXE erzeugen, die ohne Installer läuft.","1. electron-builder portable config, 2. build:win32 script, 3. Workflow upload","done (2025-06-17)"
-"E11 · Tabellen-Preset-Dropdown","Als Nutzer*in möchte ich per Dropdown zwischen vordefinierten Spalten-Ansichten umschalten können (Alle | Vertrag | Tech | Onboarding | Marketing), damit die Tabelle lesbar bleibt, ohne vertikalen Text.","1. Dropdown für Spaltenansicht 2. columnViews Objekt 3. Change-Event blendet Spalten aus","done"
-"E12 · Preset-Fix + Simple Filters","...","1. Bugfix Alle 2. Filter-UI","done (2025-06-17)"
-"S1 · Backlog Items","Drag-&-Drop Upload, XLSX Export, Umsatz/Pipeline KPI, CSV Validator","Implementation","done (2025-06-17)"
+EPIC,User Story (Akzeptanzkriterien),Kern-Tasks,Status,2025-06-17,2025-06-18
+"E1 · Robustes CSV-Handling","Als Admin möchte ich beliebige Partner-CSV-Dateien mit ≥ 30 Spalten laden, damit ich sie ohne Vorarbeit in der App ansehen kann.","1. Header-Validierung gegen Referenz-Schema (fehlende/unerwartete Spalten kennzeichnen),
+2. Fallback-Mapping (Alias-Namen wie ‚Vertragsbeginn‘/‚Contract_Start‘ erkennen),
+3. Graceful Parsing (UTF-8 +BOM, Semikolon oder Komma, Quotes, Umlaut-Handling),
+4. Leere Felder normalisieren ("")","done",
+"E2 · Skalierbare Tabellen-UI","Als Benutzer möchte ich alle Spalten horizontal scrollen können und per Spalten-Menü Spalten ein/ausblenden, damit die Ansicht übersichtlich bleibt.","1. Sticky Header + X-Scrollbar (Tailwind-Klassen anpassen),
+2. Toggle-Menü mit Checkboxen → display:none auf <th>/<td>,
+3. Persistente Sichtbarkeits-Prefs (localStorage)","done (2025-06-18)",
+"E3 · Erweiterte Filter + Suche","Als Analyst will ich jede beliebige Spalte filtern (Text, Range, Dropdown), um gezielt Datensätze zu finden.","1. Dynamische Filter-Komponente pro Spalte (Typ-Erkennung),
+2. Debounced Volltext-Suche über alle Spalten,
+3. Gespeicherte Filter-Presets","done",
+"E4 · Bearbeiten & Änderungsprotokoll","Als Power-User will ich Datensätze inline oder via Modal bearbeiten und die Änderungen als CSV exportieren.","1. Erweiterung des Modal-Editors auf alle Felder (scrollbar),
+2. Undo-/Redo-Stack im changelog-Array,
+3. Export ‚partner_export.csv‘ mit gleicher Spaltenreihenfolge","done",
+"E5 · Leistungsfähige Visualisierung","Als Manager möchte ich auch bei >1000 Zeilen KPI-Boxen und Diagramme ohne Wartezeit sehen.","1. Daten-Aggregation im Web Worker,
+2. Lazy Rendering der Chart.js-Plots (IntersectionObserver),
+3. Optionale Paginierung / Virtual Scrolling in Tabelle","done",
+"E6 · Packaging & Distribution","Als Entwickler will ich mit einem Befehl eine signierte Windows-Installer-EXE erzeugen.","1. Electron-Builder Konfig (NSIS, Icon, Auto-Update off),
+2. npm run build:win-Script,
+3. GitHub Actions CI-Workflow","done",
+"E7 · Demo- & Test-Daten","Als QA will ich mehrere Beispiel-CSV-Dateien mit Voll-Schema haben, um UI-Regressionen zu testen.","1. partner_full.csv (36 Spalten × ≥ 50 Zeilen, realistische Daten),
+2. partner_edge.csv (Extremwerte, lange URLs, Umlaut-Mix, leere Felder),
+3. Download-Knopf ‚Demo-CSV auswählen‘ im Header","done (2025-06-17)",
+"E8 · Dokumentation & Onboarding","Als neuer Mitarbeiter möchte ich in 5 Minuten verstehen, wie ich die App starte, baue und verteile.","1. README-Abschnitt ‚CSV-Schema v1.0 (Tabelle)‘,
+2. GIF oder Screenshot-Tour,
+3. Troubleshooting-Abschnitt (häufige CSV-Fehler)","done (2025-06-17)",
+"E9 · Qualität & Automatisierung","Als Maintainer möchte ich sicherstellen, dass Grundfunktionen nach jedem Commit laufen.","1. Headless Electron-Smoke-Test (Playwright) lädt partner_full.csv,
+2. ESLint + Prettier Hook,
+3. Dependabot für npm-Updates","done (2025-06-17)",
+"E10 · Portable Win-Build","Als Entwickler möchte ich eine portable Win32-EXE erzeugen, die ohne Installer läuft.","1. electron-builder portable config, 2. build:win32 script, 3. Workflow upload","done (2025-06-17)",
+"E11 · Tabellen-Preset-Dropdown","Als Nutzer*in möchte ich per Dropdown zwischen vordefinierten Spalten-Ansichten umschalten können (Alle | Vertrag | Tech | Onboarding | Marketing), damit die Tabelle lesbar bleibt, ohne vertikalen Text.","1. Dropdown für Spaltenansicht 2. columnViews Objekt 3. Change-Event blendet Spalten aus","done",
+"E12 · Preset-Fix + Simple Filters","...","1. Bugfix Alle 2. Filter-UI","done (2025-06-17)",
+"S1 · Backlog Items","Drag-&-Drop Upload, XLSX Export, Umsatz/Pipeline KPI, CSV Validator","Implementation","done (2025-06-17)",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ komplexe Build-Kette oder Cloud-Abhängigkeiten.
 
 ---
 
-## Features (v0.1)
+## Features (v0.1.1)
 
 | ✔ | Funktion |
 |---|-----------|

--- a/__tests__/statusBuckets.test.js
+++ b/__tests__/statusBuckets.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { getStatusBuckets } = require('../filterUtils');
+
+test('getStatusBuckets groups by partner', () => {
+  const data = [
+    {Partnername:'A',Vertragsstatus:'laufend'},
+    {Partnername:'A',Vertragsstatus:'geplant'},
+    {Partnername:'B',Vertragsstatus:'teilaktiv'},
+    {Partnername:'C',Vertragsstatus:''}
+  ];
+  assert.deepStrictEqual(getStatusBuckets(data), {aktiv:1, teilaktiv:1, geplant:0, unbekannt:1});
+});

--- a/about.html
+++ b/about.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>About</title>
+</head>
+<body>
+<div style="text-align:center;padding:2rem;">
+<img src="assets/icon.ico" alt="logo" style="width:64px">
+<h2>Partner Cockpit Dashboard <span id="ver"></span></h2>
+<p>Author: Jorge Muc</p>
+<p><a href="https://github.com/jorgemuc/partner-dashboard-clean">GitHub Repository</a></p>
+</div>
+<script>
+document.getElementById('ver').textContent='v'+new URLSearchParams(location.search).get('v');
+</script>
+</body>
+</html>

--- a/filterUtils.js
+++ b/filterUtils.js
@@ -5,5 +5,11 @@ const defaultFilterFields = [
 function getFilterFields(view, visible){
   return view === 'Alle' ? defaultFilterFields : visible;
 }
-if(typeof module!=='undefined') module.exports={defaultFilterFields,getFilterFields};
-if(typeof window!=='undefined') window.getFilterFields=getFilterFields;
+function getStatusBuckets(data){
+  const counts={aktiv:0,teilaktiv:0,geplant:0,unbekannt:0};
+  const seen=new Set();
+  data.forEach(r=>{const n=r.Partnername;if(seen.has(n)) return;seen.add(n);const s=String(r.Vertragsstatus||'').toLowerCase();if(/lauf/.test(s)) counts.aktiv++;else if(/teil/.test(s)) counts.teilaktiv++;else if(/plan/.test(s)) counts.geplant++;else counts.unbekannt++;});
+  return counts;
+}
+if(typeof module!=='undefined') module.exports={defaultFilterFields,getFilterFields,getStatusBuckets};
+if(typeof window!=='undefined'){window.getFilterFields=getFilterFields;window.getStatusBuckets=getStatusBuckets;}

--- a/help.html
+++ b/help.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Hilfe</title>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<style>body{font-family:Arial;margin:1rem;}article{max-width:800px;margin:auto;}</style>
+</head>
+<body>
+<article id="readme"></article>
+<script>
+fetch('README.md').then(r=>r.text()).then(t=>{
+  document.getElementById('readme').innerHTML = marked.parse(t);
+});
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <title>Partner-Dashboard v4.5</title>
+  <title>Partner-Dashboard v0.1.1</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -30,6 +30,7 @@
     th, td { white-space: nowrap; padding: 0.6rem 0.8rem; border: 1px solid #e0e0e0; text-align: left; max-width:320px; }
     th { background: #f5f5f5; position: sticky; top: 0; z-index: 2; }
     .kpi-boxes { display: flex; gap: 2rem; margin-bottom: 2rem; flex-wrap: wrap;}
+    .chart-box { flex:1 1 320px; max-height:380px; }
     .kpi {
       background: #fff; border-radius: 1rem; box-shadow: 0 2px 8px #0001; padding: 1.2rem 2rem;
       flex: 1 1 120px; min-width: 120px; text-align: center; margin-bottom: 1rem;
@@ -95,7 +96,7 @@ body.dark .log-table th { background: #3a3a3a; }
 </head>
 <body>
   <header>
-    <h1>Partner-Dashboard v4.5</h1>
+    <h1>Partner-Dashboard v0.1.1</h1>
     <button id="darkModeToggle" class="export-btn" style="background:#555;margin-left:1rem;">Dark Mode</button>
     <div class="file-upload">
       <input type="file" id="csvFile" accept=".csv" />
@@ -116,6 +117,7 @@ body.dark .log-table th { background: #3a3a3a; }
   <main>
     <!-- Übersicht -->
     <section id="overview" class="active">
+      <canvas id="barStatus" class="chart-box"></canvas>
       <div class="kpi-boxes" id="kpiBoxes"></div>
       <div>
         <p>Lade eine <strong>partner.csv</strong> hoch oder nutze Demo-Daten. Tabellenansicht zeigt alle Spalten, Filter und Editierfunktionen für wichtige Felder.</p>
@@ -154,19 +156,19 @@ body.dark .log-table th { background: #3a3a3a; }
     <!-- Chart-Tab -->
     <section id="charts">
       <div style="display:flex;flex-wrap:wrap;gap:2rem;">
-        <div style="flex:1 1 320px; min-width:260px;">
+        <div class="chart-box">
           <h3>Vertragstypen (Pie)</h3>
           <canvas id="pieVertragstyp"></canvas>
         </div>
-        <div style="flex:1 1 320px; min-width:260px;">
+        <div class="chart-box">
           <h3>Developer Portal Zugang (Pie)</h3>
           <canvas id="pieDevPortal"></canvas>
         </div>
-        <div style="flex:1 1 320px; min-width:260px;">
+        <div class="chart-box">
           <h3>Partnertyp (Bar)</h3>
           <canvas id="barPartnertyp"></canvas>
         </div>
-        <div style="flex:1 1 320px; min-width:260px;">
+        <div class="chart-box">
           <h3>Trainingsstatus (Bar)</h3>
           <canvas id="barTraining"></canvas>
         </div>
@@ -411,6 +413,19 @@ function renderKPIs() {
   document.getElementById("kpiBoxes").innerHTML = kpis.map(kpi =>
     `<div class="kpi"><div style="font-size:2rem;font-weight:bold">${kpi.value}</div><div>${kpi.label}</div></div>`
   ).join("");
+  renderStatusChart();
+}
+
+function renderStatusChart(){
+  const b=getStatusBuckets(partnerData);
+  const ctx=document.getElementById('barStatus').getContext('2d');
+  charts.barStatus?.destroy();
+  charts.barStatus=new Chart(ctx,{type:'bar',data:{labels:['Partner'],datasets:[
+    {label:'aktiv',data:[b.aktiv],stack:'s'},
+    {label:'teilaktiv',data:[b.teilaktiv],stack:'s'},
+    {label:'geplant',data:[b.geplant],stack:'s'},
+    {label:'unbekannt',data:[b.unbekannt],stack:'s'}]},
+    options:{responsive:true,plugins:{legend:{position:'bottom'}},scales:{x:{stacked:true},y:{stacked:true}}});
 }
 
 // === FILTER + EXPORT ===

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, Menu, shell, dialog } = require('electron');
 const path = require('path');
+const pkg = require('./package.json');
 
 const columnViews = {
   Alle: [],
@@ -10,12 +11,34 @@ const columnViews = {
   KPI:["Partnername","Systemname","Anzahl_Kunden","Anzahl_Liegenschaften","Anzahl_NE","Nutzungsfrequenz","Störungen_90d","Score"]
 };
 
+function createMenu(win){
+  const template=[
+    {label:'File',submenu:[
+      {label:'Info',click:()=>dialog.showMessageBox(win,{message:`Version ${pkg.appVersion}`})},
+      {role:'quit'}]},
+    {label:'Help',submenu:[
+      {label:'About ...',click:()=>{
+        const about=new BrowserWindow({parent:win,modal:true,width:400,height:300,title:'About'});
+        about.setMenu(null);
+        about.loadFile('about.html',{query:{v:pkg.appVersion}});
+      }},
+      {label:'Hilfe (Online README)',click:()=>{
+        const help=new BrowserWindow({width:600,height:700,title:'Hilfe'});
+        help.setMenu(null);
+        help.loadFile('help.html');
+      }}]}
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 1200,
-    height: 800
+    height: 800,
+    title: `Partner-Dashboard v${pkg.appVersion}`
   });
   win.loadFile(path.join(__dirname, 'index.html'));
+  createMenu(win);
 }
 
 app.whenReady().then(createWindow);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "partner-dashboard-clean",
   "version": "0.1.0",
+  "appVersion": "0.1.1",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build:win32": "electron-builder --win portable"
+    "build:win32": "electron-builder --win portable",
+    "version-bump": "node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const o=p.appVersion.split('.');o[2]=+o[2]+1;const n=o.join('.');['index.html','README.md'].forEach(f=>{let c=fs.readFileSync(f,'utf8');fs.writeFileSync(f,c.replace(new RegExp('v'+p.appVersion,'g'),'v'+n));});p.appVersion=n;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n');\""
   },
   "devDependencies": {
     "electron": "^26.2.0",
@@ -18,6 +20,6 @@
     "appId": "com.jorgemuc.partnerdashboard",
     "asar": true,
     "files": ["**/*", "!dist/**"],
-    "win": { "target": "portable", "icon": "assets/icon.ico" }
+    "win": { "target": "portable", "icon": "assets/icon.ico", "artifactName": "Portable ${productName} ${appVersion}.exe" }
   }
 }


### PR DESCRIPTION
## Summary
- add `appVersion` field and `version-bump` script
- wire up menu with About and online help windows
- display app version in title and header
- add stacked partner status bar chart
- expose new helper and tests

## Testing
- `node --test __tests__/statusBuckets.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685270cc793c832fbed40fcca9d5f344