### PR TITLE
Implement CSV validation error handling and dataStore tests

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -8,6 +8,6 @@ E11 · Tabellen-Preset-Dropdown,Spalten-Ansichten umschalten,"Dropdown UI; colum
 E12 · Preset-Fix + Simple Filters,,"Bugfix Alle; Filter-UI",done (2025-06-17),,,,,,,,,,,,,,,,,
 E13 · Context-Isolation + mitt Bus,sichere Renderer-Kommunikation,"preload setup; migrate emit/on",done (2025-07-04),,,,,,,,,,,,,,,,,
 E14 · ES-Module Refactor,Renderer strictly ESM,"import/export; jest config",done (2025-07-04),,,,,,,,,,,,,,,,,
-E15 · NSIS-Installer,signierter Installer,"builder config; cert placeholder; GH Release",todo,,,,,,,,,,,,,,,,,
+E15 · NSIS-Installer,signierter Installer,"builder config; cert placeholder; GH Release",planned,,,,,,,,,,,,,,,,,
 E16 · Virtual Scrolling,10 k Rows < 60 fps,,planned,,,,,,,,,,,,,,,,,
 E17 · Release Upload,CI erstellt GH-Release + Assets,,planned,,,,,,,,,,,,,,,,,

--- a/__tests__/dataStore.test.js
+++ b/__tests__/dataStore.test.js
@@ -16,3 +16,16 @@ test('setData stores array and emits update', () => {
     store.setData([1,2]);
   });
 });
+
+test('undo and redo reflect in store data', () => {
+  const { applyChange, undo, redo } = require('../undoRedo');
+  const log = [];
+  let idx = 0;
+  store.setData([{name:'A'},{name:'B'}]);
+  idx = applyChange(store.getData(), {index:1, field:'name', old:'B', new:'C'}, log, idx);
+  expect(store.getData()[1].name).toBe('C');
+  idx = undo(store.getData(), log, idx);
+  expect(store.getData()[1].name).toBe('B');
+  idx = redo(store.getData(), log, idx);
+  expect(store.getData()[1].name).toBe('C');
+});

--- a/__tests__/filterUtils.test.js
+++ b/__tests__/filterUtils.test.js
@@ -1,4 +1,7 @@
-const {getFilterFields,defaultFilterFields}=require('../filterUtils');
+let getFilterFields, defaultFilterFields;
+beforeAll(async () => {
+  ({ getFilterFields, defaultFilterFields } = await import('../filterUtils.js'));
+});
 
 describe('getFilterFields',()=>{
   test('returns defaults for Alle',()=>{

--- a/__tests__/parser_extended.test.js
+++ b/__tests__/parser_extended.test.js
@@ -9,8 +9,7 @@ test('parseCsv adds Umsatz and Pipeline fields when missing', () => {
   assert.equal(res.data[0].Pipeline, '');
 });
 
-test('validateCsv detects row length mismatch', () => {
+test('validateCsv throws on row length mismatch', () => {
   const csv = 'A,B\n1,2,3';
-  const result = validateCsv(csv);
-  assert.equal(result.valid, false);
+  assert.throws(() => validateCsv(csv), /README#troubleshooting/);
 });

--- a/chartWorker.js
+++ b/chartWorker.js
@@ -13,6 +13,13 @@ export function buildChart(field, rows){
   return { labels: Object.keys(counts), values: Object.values(counts) };
 }
 
+let bus;
+try {
+  ({ default: bus } = await import('../src/renderer/eventBus.js'));
+} catch (e) {
+  self.postMessage({ error: 'eventBus import failed – see README#troubleshooting' });
+}
+
 self.onmessage = ({data}) => {
   const {id, field, rows} = data;
   const { labels, values } = buildChart(field, rows);

--- a/filterUtils.js
+++ b/filterUtils.js
@@ -1,9 +1,7 @@
-const defaultFilterFields = [
+export const defaultFilterFields = [
   "Partnername","Systemname","Partnertyp",
   "Branche","Vertragsstatus","Vertragstyp"
 ];
-function getFilterFields(view, visible){
+export function getFilterFields(view, visible){
   return view === 'Alle' ? defaultFilterFields : visible;
 }
-if(typeof module!=='undefined') module.exports={defaultFilterFields,getFilterFields};
-if(typeof window!=='undefined'){window.getFilterFields=getFilterFields;}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
-  <script src="filterUtils.js"></script>
+  <script type="module" src="filterUtils.js"></script>
   <link rel="stylesheet" href="styles.css">
   <style>
     body { font-family: Arial, sans-serif; margin: 0; background: #f9f9fb;}

--- a/parser.js
+++ b/parser.js
@@ -55,11 +55,13 @@ function validateCsv(raw){
   raw = (raw || '').replace(/^\uFEFF/, '');
   const res = Papa.parse(raw, { skipEmptyLines: true });
   if(res.errors && res.errors.length){
-    return { valid:false, errors: res.errors.map(e=>e.message) };
+    throw new Error(res.errors.map(e=>e.message).join('; '));
   }
   const cols = res.data[0] ? res.data[0].length : 0;
-  const inconsistent = res.data.some(r => r.length !== cols);
-  if(inconsistent) return { valid:false, errors:["Inconsistent column count"] };
+  const idx = res.data.findIndex(r => r.length !== cols);
+  if(idx !== -1){
+    throw new Error(`Row ${idx+1} has wrong column count – see README#troubleshooting`);
+  }
   return { valid:true, errors:[] };
 }
 

--- a/scripts/e2e-smoke.js
+++ b/scripts/e2e-smoke.js
@@ -25,7 +25,8 @@ async function run(){
   global.localStorage = dom.window.localStorage;
   global.sessionStorage = dom.window.sessionStorage;
   global.window.api = {version:()=>Promise.resolve('0.0.0'),onOpenCsvDialog:()=>{}};
-  global.getFilterFields = dom.window.getFilterFields;
+  const utils = await import('../filterUtils.js');
+  global.getFilterFields = utils.getFilterFields;
   dom.window.HTMLCanvasElement.prototype.getContext = () => ({})
   global.Chart = function(){ return {destroy(){}} };
   global.Chart.register = () => {};

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -2,6 +2,7 @@ import { getData, setData } from './dataStore.js';
 import eventBus from './eventBus.js';
 import { getStatusBuckets } from './utils.js';
 import { renderKPIs, setChartsRef } from './kpi.js';
+import { getFilterFields } from '../../filterUtils.js';
 const I18N={
   de:{demoBtn:"Demo-Daten laden"}
 }; // TODO(Epic-9)


### PR DESCRIPTION
## Summary
- update backlog progress
- convert `filterUtils.js` to ESM and load via module script
- fix chart worker to load event bus via relative import
- throw explicit error from `validateCsv`
- adjust renderer to import new utilities
- update tests for filterUtils, parser and dataStore
- adjust smoke test for module util

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bd8aab904832fa4c8b291b715426e