### PR TITLE
fix(preload): switch to ESM import for mitt

### DIFF
--- a/__tests__/eventBus.test.js
+++ b/__tests__/eventBus.test.js
@@ -3,8 +3,11 @@ jest.mock('electron', () => ({
   ipcRenderer: { invoke: jest.fn(), on: jest.fn() }
 }));
 const { contextBridge } = require('electron');
-require('../preload.js');
-const bus = contextBridge.exposeInMainWorld.mock.calls[0][1].bus;
+let bus;
+beforeAll(async () => {
+  await import('../src/preload.mjs');
+  bus = contextBridge.exposeInMainWorld.mock.calls[0][1].bus;
+});
 
 describe('event bus', () => {
   test('emit calls handler registered via on', () => {

--- a/__tests__/renderer.init.test.js
+++ b/__tests__/renderer.init.test.js
@@ -8,7 +8,7 @@ jest.mock('../chartWorker.js', () => ({
 }));
 
 test('renderer bootstraps without errors', async () => {
-  require('../preload.js');
+  await import('../src/preload.mjs');
   global.window = { api: contextBridge.exposeInMainWorld.mock.calls[0][1], electronAPI: { getVersion: jest.fn(() => Promise.resolve('1.0.0')) } };
   const bus = global.window.api.bus;
   expect(bus).toBeDefined();

--- a/src/preload.mjs
+++ b/src/preload.mjs
@@ -1,8 +1,10 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 const { contextBridge, ipcRenderer } = require('electron');
 
 let bus;
 try {
-  const mitt = require('mitt');
+  const { default: mitt } = await import('mitt');
   bus = mitt();
   bus.once = (t, h) => {
     const wrap = (...args) => {

--- a/tests/eventBus.spec.js
+++ b/tests/eventBus.spec.js
@@ -15,7 +15,7 @@ test('eventBus module exports mitt instance', async () => {
     ipcRenderer: { invoke: jest.fn(), on: jest.fn() }
   }));
   const { contextBridge } = require('electron');
-  require('../preload.js');
+  await import('../src/preload.mjs');
   const bus = contextBridge.exposeInMainWorld.mock.calls[0][1].bus;
   expect(typeof bus.emit).toBe('function');
 });


### PR DESCRIPTION
## Summary
- rename `preload.js` to `src/preload.mjs`
- load `mitt` via dynamic `import`
- adjust unit tests to new preload path and ES module

## Testing
- `npm run dev` *(fails: Missing script)*
- `npm run dist` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5d43dc30832f90844e7043f9b9ff