### PR TITLE
Fix preload and update renderer bus usage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "rules": {
     "node/no-missing-require": "error",
     "node/no-unsupported-features/es-syntax": "warn",
-    "node/no-missing-import": "error"
+    "node/no-missing-import": "error",
+    "node/no-extraneous-require": "error"
   }
 }

--- a/__tests__/dataStore.test.js
+++ b/__tests__/dataStore.test.js
@@ -1,8 +1,8 @@
 let store, bus;
 beforeAll(async () => {
-  global.window = { api: { bus: require('mitt')() } };
+  global.window = { bus: require('mitt')() };
   store = await import('../src/renderer/dataStore.js');
-  bus = global.window.api.bus;
+  bus = global.window.bus;
 
 });
 

--- a/__tests__/eventBus.test.js
+++ b/__tests__/eventBus.test.js
@@ -6,7 +6,8 @@ const { contextBridge } = require('electron');
 let bus;
 beforeAll(async () => {
   await import('../src/preload.js');
-  bus = contextBridge.exposeInMainWorld.mock.calls[0][1].bus;
+  const call = contextBridge.exposeInMainWorld.mock.calls.find(c => c[0] === 'bus');
+  bus = call ? call[1] : undefined;
 });
 
 describe('event bus', () => {
@@ -33,7 +34,9 @@ describe('event bus', () => {
       throw new Error('missing');
     });
     await import('../src/preload.js');
-    const fallback = contextBridge.exposeInMainWorld.mock.calls.at(-1)[1].bus;
+    const reversed = [...contextBridge.exposeInMainWorld.mock.calls].reverse();
+    const fallbackCall = reversed.find(c => c[0] === 'bus');
+    const fallback = fallbackCall ? fallbackCall[1] : undefined;
     expect(() => fallback.emit('x')).not.toThrow();
     jest.dontMock('mitt');
   });

--- a/__tests__/renderer.init.test.js
+++ b/__tests__/renderer.init.test.js
@@ -9,7 +9,9 @@ jest.mock('../chartWorker.js', () => ({
 
 test('renderer bootstraps without errors', async () => {
   await import('../src/preload.js');
-  global.window = { api: contextBridge.exposeInMainWorld.mock.calls[0][1], electronAPI: { getVersion: jest.fn(() => Promise.resolve('1.0.0')) } };
-  const bus = global.window.api.bus;
+  const apiCall = contextBridge.exposeInMainWorld.mock.calls.find(c => c[0] === 'api');
+  global.window = { api: apiCall ? apiCall[1] : {}, electronAPI: { getVersion: jest.fn(() => Promise.resolve('1.0.0')) } };
+  global.window.bus = global.window.api.bus;
+  const bus = global.window.bus;
   expect(bus).toBeDefined();
 });

--- a/app/dataStore.js
+++ b/app/dataStore.js
@@ -1,5 +1,4 @@
-const mitt = require('mitt');
-const bus = mitt();
+const bus = window.bus;
 let partnerData = [];
 module.exports.getData = () => partnerData;
 module.exports.setData = function(arr){

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -1,8 +1,7 @@
 const { ipcRenderer, shell, dialog } = require('electron');
 const fs = require('fs');
 const { getData, setData } = require('./dataStore.js');
-const mitt = require('mitt');
-const bus = mitt();
+const bus = window.bus;
 const { getStatusBuckets } = require('../assets/utils.js');
 const I18N={
   de:{demoBtn:"Demo-Daten laden"}

--- a/scripts/e2e-smoke.js
+++ b/scripts/e2e-smoke.js
@@ -32,7 +32,7 @@ async function run(){
   global.Chart.register = () => {};
   global.Papa = {parse:()=>({data:[]}), unparse:()=>''};
   global.XLSX = {utils:{json_to_sheet:()=>({}),book_new:()=>({}),book_append_sheet(){}} ,write:()=>''};
-  global.window.api.bus = require('mitt')();
+  global.window.bus = require('mitt')();
   await import('../src/renderer/dataStore.js');
   await import('../src/renderer/renderer.js');
   dom.window.document.getElementById('demoDataBtn').click();

--- a/src/preload.js
+++ b/src/preload.js
@@ -21,6 +21,7 @@ try {
   };
 }
 
+contextBridge.exposeInMainWorld('bus', bus);
 contextBridge.exposeInMainWorld('api', {
   bus,
   getVersion: () => ipcRenderer.invoke('get-version'),

--- a/src/renderer/dataStore.js
+++ b/src/renderer/dataStore.js
@@ -1,4 +1,4 @@
-const bus = window.api.bus;
+const bus = window.bus;
 let partnerData = [];
 export const getData = () => partnerData;
 export function setData(arr){

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,5 +1,5 @@
 import { getData, setData } from './dataStore.js';
-const eventBus = window.api.bus;
+const eventBus = window.bus;
 import { getStatusBuckets } from './utils.js';
 import { renderKPIs, setChartsRef } from './kpi.js';
 const { getFilterFields } = window.filterUtils;

--- a/tests/eventBus.spec.js
+++ b/tests/eventBus.spec.js
@@ -16,6 +16,7 @@ test('eventBus module exports mitt instance', async () => {
   }));
   const { contextBridge } = require('electron');
   await import('../src/preload.js');
-  const bus = contextBridge.exposeInMainWorld.mock.calls[0][1].bus;
+  const call = contextBridge.exposeInMainWorld.mock.calls.find(c => c[0] === 'bus');
+  const bus = call ? call[1] : undefined;
   expect(typeof bus.emit).toBe('function');
 });

--- a/tests/smoke/preload.test.js
+++ b/tests/smoke/preload.test.js
@@ -3,7 +3,7 @@ const { _electron: electron } = require('playwright');
 const path = require('path');
 
 test('App starts ohne Preload-Fehler', async () => {
-  const app = await electron.launch({ args: ['.'] });
+  const app = await electron.launch({ args: ['.', '--no-sandbox'], env:{ ELECTRON_DISABLE_SANDBOX:'1' } });
   const page = await app.firstWindow();
 
   const logs = [];
@@ -12,7 +12,9 @@ test('App starts ohne Preload-Fehler', async () => {
   await page.waitForSelector('body');
   await app.close();
 
-  const bad = /MODULE_NOT_FOUND|Unable to load preload|bus.+undefined/i;
+  const bad = /MODULE_NOT_FOUND|Unable to load preload|bus.*undefined/i;
   expect(logs.some(l => bad.test(l))).toBeFalsy();
+  const hasBus = await page.evaluate(() => !!window.bus);
+  expect(hasBus).toBe(true);
 }, 30_000);
 


### PR DESCRIPTION
## Summary
- define `window.bus` in preload
- use global bus object across renderer scripts
- smoke test for preload bus errors
- enforce missing-require lint rule

## Testing
- `npm run lint`
- `npm test`
- `npm run smoke` *(fails: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_685cddfb4374832f820c3ebdeecc7f1e