### PR TITLE
Refactor preload boundary and renderer bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,14 @@ Bare specifiers (`import foo from 'foo'`) are forbidden. Either expose required 
 
 ### Versioning
 Patch bumps fix bugs only. Increase minor for new features, major for breaking changes.
+
+### Preload Contract
+`window.api` is the single global exposed to the renderer. It has the shape:
+
+```
+{
+  bus: MittEmitter,
+  libs: { Papa?: any, XLSX?: any, Chart?: any },
+  version: () => string
+}
+```

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -52,3 +52,4 @@ E9 · Qualität & Automatisierung,preload esm + feature flags,,done,,codex,
 E9 · Qualität & Automatisierung,esbuild minify + chart tree shake,,done,,codex,
 E15 - Renderer Bugfixes,Demo + CSV load fails,preload+tabs+version fix,done,,codex,
 E15 - Renderer Bugfixes,packaging cleanups,dup esbuild + version,done,,codex,
+E17 - Preload Refactor,Preload boundary cleanup,libs->renderer|map file,done,Maintainability,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## v0.5.0 - 2025-06-28
+* refactor preload boundary; libs move to renderer
+* esbuild outputs renderer.bundle.js.map
+* tests and docs updated
+* bump version to 0.5.0
 ## v0.4.1 - 2025-06-27
 * fix duplicate esbuild entry in package.json
 * bump version to 0.4.1

--- a/__tests__/bundle.test.js
+++ b/__tests__/bundle.test.js
@@ -7,6 +7,7 @@ test('bundle writes version file and renderer bundle', () => {
   execFileSync('node', ['scripts/bundle.js']);
   expect(existsSync('dist/version.json')).toBe(true);
   expect(existsSync('dist/renderer.bundle.js')).toBe(true);
+  expect(existsSync('dist/renderer.bundle.js.map')).toBe(true);
   const data = JSON.parse(readFileSync('dist/version.json', 'utf8'));
   expect(data.version).toBe(version);
 });

--- a/__tests__/renderer.init.test.js
+++ b/__tests__/renderer.init.test.js
@@ -1,8 +1,5 @@
-jest.mock('electron', () => ({__esModule: true, contextBridge: { exposeInMainWorld: jest.fn() }, ipcRenderer: { invoke: jest.fn(() => Promise.resolve('1.2.3')), on: jest.fn() }  , default: {} } ));
+jest.mock('electron', () => ({__esModule: true, contextBridge: { exposeInMainWorld: jest.fn() }, default: {} }));
 const { contextBridge } = require('electron');
-jest.mock('papaparse', () => ({}));
-jest.mock('xlsx', () => ({ utils: {} }));
-jest.mock('chart.js', () => function(){});
 jest.mock('papaparse', () => ({}));
 jest.mock('xlsx', () => ({ utils: {} }));
 jest.mock('chart.js', () => function(){});
@@ -17,7 +14,5 @@ test('renderer bootstraps without errors', async () => {
   global.window = { api: apiCall ? apiCall[1] : {} };
   expect(global.window.api.bus).toBeDefined();
   expect(typeof global.window.api.version).toBe('function');
-  expect(global.window.api.libs.Papa).toBeDefined();
-  expect(global.window.api.libs.XLSX).toBeDefined();
-  expect(global.window.api.libs.Chart).toBeDefined();
+  expect(typeof global.window.api.libs).toBe('object');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -16,7 +16,7 @@ esbuild.build({
   define: { 'process.env.NODE_ENV': '"production"' },
   external: ['electron'],
   plugins: [importGlob()],
-  sourcemap: process.env.NODE_ENV !== 'production',
+  sourcemap: true,
   logLevel: 'info'
 }).catch(() => process.exit(1));
 

--- a/scripts/e2e-smoke.js
+++ b/scripts/e2e-smoke.js
@@ -26,13 +26,9 @@ async function run(){
   global.sessionStorage = dom.window.sessionStorage;
   global.window.api = {version:()=>Promise.resolve('0.0.0'),onOpenCsvDialog:()=>{}};
   dom.window.HTMLCanvasElement.prototype.getContext = () => ({})
-  global.Chart = function(){ return {destroy(){}} };
-  global.Chart.register = () => {};
-  global.Papa = {parse:()=>({data:[]}), unparse:()=>''};
-  global.XLSX = {utils:{json_to_sheet:()=>({}),book_new:()=>({}),book_append_sheet(){}} ,write:()=>''};
   global.window.api = {
     bus: require('mitt')(),
-    libs: { Papa: global.Papa, XLSX: global.XLSX, Chart: global.Chart }
+    libs: {}
   };
 
   // —— IPC-Ready-Signal zum Smoke-Test ————————————————

--- a/scripts/lint-no-bare-imports.js
+++ b/scripts/lint-no-bare-imports.js
@@ -14,7 +14,9 @@ function scan(p) {
       const m = line.match(/^\s*import\s.*?from\s+["']([^"']+)["']/);
       if (m) {
         const spec = m[1];
-        if (!spec.startsWith('./') && !spec.startsWith('../') && !spec.startsWith('https://') && !['mitt','chart.js'].includes(spec)) {
+        const allowed = ['mitt','papaparse','xlsx'];
+        const isChart = spec.startsWith('chart.js');
+        if (!spec.startsWith('./') && !spec.startsWith('../') && !spec.startsWith('https://') && !allowed.includes(spec) && !isChart) {
           console.error(`Bare import '${spec}' in ${path.relative(process.cwd(), p)}:${i+1}`);
           hasError = true;
         }

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,13 +1,21 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge } = require('electron');
+const { readFileSync } = require('fs');
+const { join } = require('path');
 const mitt = require('mitt');
-let Papa, XLSX, Chart;
-try { Papa = require('papaparse'); } catch {}
-try { XLSX = require('xlsx'); } catch {}
-try { Chart = require('chart.js'); } catch {}
+
+let version = 'dev';
+try {
+  const data = readFileSync(join(__dirname, '../dist/version.json'), 'utf8');
+  version = JSON.parse(data).version;
+} catch (e) {
+  console.error('[pl-err] failed to load version', e);
+}
 
 const bus = mitt();
+const libs = {};
+
 contextBridge.exposeInMainWorld('api', {
   bus,
-  libs: { Papa, XLSX, Chart },
-  version: () => ipcRenderer.invoke('get-version')
+  libs,
+  version: () => version
 });

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,12 +1,17 @@
-const { Papa, XLSX, Chart } = window.api.libs;
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+import Chart from 'chart.js/auto';
+import { applyFilters, getFilterFields } from '../shared/filterUtils.mjs';
+import { getData, setData } from './dataStore.js';
+import { getStatusBuckets } from './utils.js';
+import { renderKPIs, setChartsRef } from './kpi.js';
+const eventBus = window.api.bus;
+window.api.libs.Papa = Papa;
+window.api.libs.XLSX = XLSX;
+window.api.libs.Chart = Chart;
 if(!Papa){ document.body.classList.add('no-csv'); showMsg('CSV disabled', 'error'); }
 if(!Chart){ document.body.classList.add('no-chart'); showMsg('Charts disabled', 'error'); }
 const { utils: XLSXUtils = {}, writeFile = () => {} } = XLSX || {};
-import { applyFilters, getFilterFields } from '../shared/filterUtils.mjs';
-import { getData, setData } from './dataStore.js';
-const eventBus = window.api.bus;
-import { getStatusBuckets } from './utils.js';
-import { renderKPIs, setChartsRef } from './kpi.js';
 const I18N={
   de:{demoBtn:"Demo-Daten laden"}
 }; // TODO(Epic-9)

--- a/tests/eventBus.spec.js
+++ b/tests/eventBus.spec.js
@@ -11,8 +11,7 @@ test('eventBus module exports mitt instance', async () => {
   });
   global.window = dom.window;
   jest.mock('electron', () => ({__esModule: true,
-    contextBridge: { exposeInMainWorld: jest.fn() },
-    ipcRenderer: { invoke: jest.fn(() => Promise.resolve('0.0.0')), on: jest.fn() }
+    contextBridge: { exposeInMainWorld: jest.fn() }
   }));
   const { contextBridge } = require('electron');
   await import('../src/preload.js');


### PR DESCRIPTION
## Summary
- expose minimal preload contract with bus, libs and version
- load runtime libs in the renderer and register on `window.api`
- generate sourcemap for renderer bundle and update lint rule
- document new preload contract
- update tests, backlog and changelog for v0.5.0

## Testing
- `npm test`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_685e4277cef0832fadda65daf9a95c7c