### PR TITLE
Fix preload and renderer bridge

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -53,3 +53,4 @@ E9 · Qualität & Automatisierung,esbuild minify + chart tree shake,,done,,codex
 E15 - Renderer Bugfixes,Demo + CSV load fails,preload+tabs+version fix,done,,codex,
 E15 - Renderer Bugfixes,packaging cleanups,dup esbuild + version,done,,codex,
 E17 - Preload Refactor,Preload boundary cleanup,libs->renderer|map file,done,Maintainability,S,codex
+E17 - Preload Refactor,Renderer bridge hotfix,v0.5.1 release,in progress,Maintainability,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.5.1 – Preload stabilisiert; Renderer-Bridge repariert; UI reagiert wieder
+
 ## v0.5.0 - 2025-06-28
 * refactor preload boundary; libs move to renderer
 * esbuild outputs renderer.bundle.js.map

--- a/__tests__/renderer.init.test.js
+++ b/__tests__/renderer.init.test.js
@@ -13,6 +13,6 @@ test('renderer bootstraps without errors', async () => {
   const apiCall = contextBridge.exposeInMainWorld.mock.calls.find(c => c[0] === 'api');
   global.window = { api: apiCall ? apiCall[1] : {} };
   expect(global.window.api.bus).toBeDefined();
-  expect(typeof global.window.api.version).toBe('function');
+  expect(typeof global.window.api.version).toBe('string');
   expect(typeof global.window.api.libs).toBe('object');
 });

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@ document.getElementById('repoLink').onclick=e=>{
   e.preventDefault();
   window.open('https://github.com/jorgemuc/partner-dashboard-clean');
 };
-document.getElementById('ver').textContent = 'v'+(window.api?.version()?window.api.version():'dev');
+document.getElementById('ver').textContent = 'v'+(window.api?.version || 'dev');
 </script>
 </body>
 </html>

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -253,9 +253,8 @@ function showMsg(txt, type="success") {
   setTimeout(() => { msgDiv.innerHTML = ""; }, 4000);
 }
 
-window.api.version().then(v=>{
-  window.showVersion=()=>dialog.showMessageBox({title:'Partner-Dashboard',message:`Version ${v}`});
-});
+const v = window.api.version || 'dev';
+window.showVersion=()=>dialog.showMessageBox({title:'Partner-Dashboard',message:`Version ${v}`});
 
 ipcRenderer.on('open-csv-dialog', () => document.getElementById('csvFile').click());
 

--- a/help.html
+++ b/help.html
@@ -13,7 +13,7 @@
 fetch('README.md').then(r=>r.text()).then(t=>{
   document.getElementById('readme').innerHTML = marked.parse(t);
 });
-document.getElementById('ver').textContent = 'v'+(window.api?.version()?window.api.version():'dev');
+document.getElementById('ver').textContent = 'v'+(window.api?.version || 'dev');
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const ver = window.api?.version ? window.api.version() : 'dev';
+      const ver = window.api?.version || 'dev';
       document.getElementById('appTitle').textContent =
         `Partner-Dashboard v${ver}`;
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -12,7 +12,7 @@
     "pack": "electron-builder --dir",
     "postinstall": "node scripts/decode-icons.js",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
-    "smoke": "echo \"Smoke tests disabled\"",
+    "smoke": "playwright test tests/smoke/preload.test.js",
     "ci": "npm run lint && npm test && npm run bundle && npm run build",
     "postversion": "npm run bundle"
   },

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,17 +1,20 @@
-import Papa from 'papaparse';
-import * as XLSX from 'xlsx';
-import Chart from 'chart.js/auto';
 import { applyFilters, getFilterFields } from '../shared/filterUtils.mjs';
 import { getData, setData } from './dataStore.js';
 import { getStatusBuckets } from './utils.js';
 import { renderKPIs, setChartsRef } from './kpi.js';
+
+const { libs } = window.api || {};
+if (!libs) {
+  console.error('API-Bridge fehlt – Abbruch');
+  throw new Error('preload missing');
+}
+const { mitt: Mitt, Papa, XLSX, Chart } = libs;
 const eventBus = window.api.bus;
-window.api.libs.Papa = Papa;
-window.api.libs.XLSX = XLSX;
-window.api.libs.Chart = Chart;
-if(!Papa){ document.body.classList.add('no-csv'); showMsg('CSV disabled', 'error'); }
-if(!Chart){ document.body.classList.add('no-chart'); showMsg('Charts disabled', 'error'); }
 const { utils: XLSXUtils = {}, writeFile = () => {} } = XLSX || {};
+if(!Papa){ document.body.classList.add('no-csv'); console.error('CSV disabled'); }
+if(!Chart){ document.body.classList.add('no-chart'); console.error('Charts disabled'); }
+const demoBtn = document.getElementById('demoDataBtn');
+if(demoBtn && !Papa) demoBtn.disabled = true;
 const I18N={
   de:{demoBtn:"Demo-Daten laden"}
 }; // TODO(Epic-9)
@@ -278,7 +281,7 @@ function renderOverview(){
 
 // tolerate missing preload bridge in jsdom/Jest
 (function(){
-  const version = window.api?.version ? window.api.version() : 'dev-test';
+  const version = window.api?.version || 'dev-test';
   appVersion = version;
   window.showVersion = () => alert(`Version ${version}`);
   renderAll();
@@ -311,8 +314,8 @@ function renderFilters() {
   html += `<select id="presetSelect"><option value="">Preset wählen</option>`+
     presets.map((p,i)=>`<option value="${i}">${p.name}</option>`).join('')+`</select>`;
   html += `<button id="savePreset" class="export-btn" style="background:#888;">Preset speichern</button>`;
-  html += `<button class="export-btn" onclick="exportTableCSV()">CSV Export</button>`;
-  html += `<button class="export-btn" onclick="exportTableXLSX()">XLSX Export</button>`;
+  html += `<button class="export-btn" onclick="exportTableCSV()" ${!Papa?'disabled':''}>CSV Export</button>`;
+  html += `<button class="export-btn" onclick="exportTableXLSX()" ${!XLSX?'disabled':''}>XLSX Export</button>`;
   thead.querySelector('.filter-row')?.remove();
   if(csvHeaders.length>20){
     div.innerHTML='';

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,2 +1,1 @@
-// load bundled renderer for integration-style tests
-import('../dist/renderer.bundle.js').catch(() => {});
+// no-op setup for jest

--- a/tests/smoke/preload.test.js
+++ b/tests/smoke/preload.test.js
@@ -1,18 +1,20 @@
 const { test, expect } = require('@playwright/test');
 const { _electron: electron } = require('playwright');
-const path = require('path');
+const { version } = require('../../package.json');
 
-test('App starts und sendet ready-IPC', async () => {
+test('App exposes version and demo button', async () => {
   const app = await electron.launch({ args: ['.', '--no-sandbox'], env:{ ELECTRON_DISABLE_SANDBOX:'1' } });
 
   // wait for the main process "app-loaded" signal
   await app.waitForEvent('ipc', (_e, msg) => msg === 'app-loaded');
 
   const page = await app.firstWindow();
-
-  const hasBus = await page.evaluate(() =>
-    !!window.api?.bus && typeof window.api.bus.emit === 'function');
-  expect(hasBus).toBe(true);
+  const res = await page.evaluate(() => ({
+    version: window.api?.version,
+    demoEnabled: !document.getElementById('demoDataBtn').disabled
+  }));
+  expect(res.version).toBe(version);
+  expect(res.demoEnabled).toBe(true);
   await app.close();
 }, 30_000);
 


### PR DESCRIPTION
## Summary
- expose libs and version from preload synchronously
- adapt renderer to preload bridge
- adjust renderer startup guard and UI fallbacks
- simplify smoke test
- reenable smoke script and bump version

## Testing
- `npm test`
- `npm run smoke` *(fails: Process failed to launch)*
- `npm run build` *(fails: wine is required)*

------
https://chatgpt.com/codex/tasks/task_e_685e46675b3c832fbee71c882ed4e4c2