### PR TITLE
Improve CI bundle workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,11 @@ on:
     branches: [main]
 
 jobs:
-  build-win:
-    runs-on: windows-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -31,24 +34,16 @@ jobs:
         run: npm run bundle
 
       - name: Ensure preload bundle exists
-        run: |
-          if (-not (Test-Path 'dist/preload.js')) {
-            Write-Error 'dist/preload.js missing'
-            exit 1
-          }
-        shell: pwsh
+        run: node -e "const fs=require('fs'); if(!fs.existsSync('dist/preload.js')){console.error('dist/preload.js missing'); process.exit(1);}"
 
       - name: Run unit tests
         run: npm test
 
-      - name: Bundle sources
-        run: npm run bundle
+      - name: Build app
+        run: npm run build
 
-      - name: Build portable win32
-        run: npm run build:win32       # electron-builder --win portable
-
-      - name: Upload portable EXE
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: partner-dashboard-win
+          name: partner-dashboard-${{ matrix.os }}
           path: dist/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 assets/icons/*.png
-dist/*
+dist/**
 !dist/version.json

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -55,3 +55,4 @@ E15 - Renderer Bugfixes,packaging cleanups,dup esbuild + version,done,,codex,
 E17 - Preload Refactor,Preload boundary cleanup,libs->renderer|map file,done,Maintainability,S,codex
 E17 - Preload Refactor,Renderer bridge hotfix,v0.5.1 release,done,Maintainability,S,codex
 E17 - Preload Refactor,preload bundling & CI,ensure dist/preload.js,done,,codex,
+E18 - Build Automation,CI cross-platform,run bundle->test->build,done,,codex,

--- a/package.json
+++ b/package.json
@@ -6,14 +6,13 @@
     "start": "electron .",
     "lint": "eslint main.js src/preload.cjs",
     "bundle": "node scripts/bundle.js",
-    "prebuild:win32": "npm run bundle",
     "build:win32": "electron-builder --win portable",
     "build": "npm run build:win32",
     "pack": "electron-builder --dir",
     "postinstall": "node scripts/decode-icons.js",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "smoke": "playwright test tests/smoke/preload.test.js",
-    "ci": "npm run lint && npm run bundle && npm test && npm run bundle && npm run build",
+    "ci": "npm run lint && npm run bundle && npm test && npm run build",
     "postversion": "npm run bundle"
   },
   "devDependencies": {

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -4,33 +4,41 @@ const importGlob = require('esbuild-plugin-import-glob').default;
 const { version } = require('../package.json');
 const { mkdirSync, writeFileSync } = require('node:fs');
 
-mkdirSync('dist', { recursive: true });
+async function bundle() {
+  mkdirSync('dist', { recursive: true });
 
-esbuild.build({
-  entryPoints: ['src/preload.cjs'],
-  bundle: true,
-  minify: true,
-  platform: 'node',
-  format: 'cjs',
-  target: ['node16'],
-  outfile: 'dist/preload.js',
-  logLevel: 'info'
-}).catch(() => process.exit(1));
+  await Promise.all([
+    esbuild.build({
+      entryPoints: ['src/preload.cjs'],
+      bundle: true,
+      minify: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node16'],
+      outfile: 'dist/preload.js',
+      logLevel: 'info'
+    }),
+    esbuild.build({
+      entryPoints: ['src/renderer/renderer.js'],
+      bundle: true,
+      minify: true,
+      treeShaking: true,
+      outfile: 'dist/renderer.bundle.js',
+      format: 'esm',
+      target: ['es2022'],
+      define: { 'process.env.NODE_ENV': '"production"' },
+      external: ['electron'],
+      plugins: [importGlob()],
+      sourcemap: true,
+      logLevel: 'info'
+    })
+  ]);
 
-esbuild.build({
-  entryPoints: ['src/renderer/renderer.js'],
-  bundle: true,
-  minify: true,
-  treeShaking: true,
-  outfile: 'dist/renderer.bundle.js',
-  format: 'esm',
-  target: ['es2022'],
-  define: { 'process.env.NODE_ENV': '"production"' },
-  external: ['electron'],
-  plugins: [importGlob()],
-  sourcemap: true,
-  logLevel: 'info'
-}).catch(() => process.exit(1));
+  writeFileSync('dist/version.json', JSON.stringify({ version }, null, 2) + '\n');
+  console.log('[bundle] wrote dist files');
+}
 
-writeFileSync('dist/version.json', JSON.stringify({ version }, null, 2) + '\n');
-console.log('[bundle] wrote dist files');
+bundle().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- tweak `.gitignore` so only `dist/version.json` is versioned
- refactor `scripts/bundle.js` to async/await with Promise-based esbuild
- update GitHub Action for Windows/Linux matrix and single bundle step
- simplify `ci` script in `package.json`
- document progress in `BACKLOG.csv`

## Testing
- `npm test`
- `npm run smoke` *(fails: electron failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_685e68e2fc8c832f9059697d1d42dd87