### PR TITLE
Fix Chart.js bundling and worker

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -64,3 +64,4 @@ E23 - Stability,preload externals,bundled via esbuild,done,,codex,
 E24 - Node externals bugfix,mark built-ins external,renderer libs import,done,,codex,
 E25 - Preload bundling,bundle mitt,preload loads again,done,,codex,
 E26 - CSV Input Fix,Renderer reads files directly,loadCsvFile helper|drag&drop handler,done,UX,S,codex
+E27 - Chart bundling fix,Charts not rendered,inline worker|global Chart,done,Fix,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v0.5.13 - chart worker bundled
+* Chart.js bundled into renderer and exposed globally
+* worker code loaded via Blob URL
 ## v0.5.12 - CSV import bugfix
 * file input and drag-drop parse CSV in renderer
 ## v0.5.11 - preload mitt bundled

--- a/__tests__/loadCsvFile.test.js
+++ b/__tests__/loadCsvFile.test.js
@@ -19,7 +19,7 @@ beforeAll(async () => {
   global.localStorage = dom.window.localStorage;
   window.HTMLCanvasElement.prototype.getContext = () => ({});
   global.Chart = function(){};
-  window.api = { libs:{ Papa: require('papaparse'), Chart: global.Chart }, bus: mitt(), version:'0' };
+  window.api = { libs:{ Papa: require('papaparse') }, bus: mitt(), version:'0' };
   window.FileReader = class { constructor(){ this.onload=null; } readAsText(){ this.onload({target:{result:'A\n1'}}); } };
   global.FileReader = window.FileReader;
   store = await import('../src/renderer/dataStore.js');

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,6 +1,7 @@
 export default {
   moduleNameMapper: {
-    '\\.(css|png)$': 'identity-obj-proxy'
+    '\\.(css|png)$': 'identity-obj-proxy',
+    '\\?raw$': '<rootDir>/tests/rawLoader.js'
   },
   setupFilesAfterEnv: ['<rootDir>/tests/jest.setup.js'],
   testEnvironmentOptions: { resources: 'usable' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -12,8 +12,7 @@ function safeRequire(name) {
 const libs = {
   mitt,
   Papa: safeRequire('papaparse'),
-  XLSX: safeRequire('xlsx'),
-  Chart: safeRequire('chart.js/auto')
+  XLSX: safeRequire('xlsx')
 };
 
 let version = 'dev';

--- a/tests/rawLoader.js
+++ b/tests/rawLoader.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/tests/smoke/preload.test.js
+++ b/tests/smoke/preload.test.js
@@ -2,7 +2,7 @@ const { test, expect } = require('@playwright/test');
 const { _electron: electron } = require('playwright');
 const { version } = require('../../package.json');
 
-test('App exposes version and demo button', async () => {
+test('App exposes version and renders charts', async () => {
   const app = await electron.launch({ args: ['.', '--no-sandbox'], env:{ ELECTRON_DISABLE_SANDBOX:'1' } });
 
   // wait for the main process "app-loaded" signal
@@ -15,6 +15,10 @@ test('App exposes version and demo button', async () => {
   }));
   expect(res.version).toBe(version);
   expect(res.demoEnabled).toBe(true);
+  await page.click('#demoDataBtn');
+  await page.waitForSelector('canvas.chartjs-render-monitor');
+  const count = await page.evaluate(() => document.querySelectorAll('canvas.chartjs-render-monitor').length);
+  expect(count).toBeGreaterThan(0);
   await app.close();
 }, 30_000);
 


### PR DESCRIPTION
## Summary
- expose Chart.js only in renderer
- inline chart worker at build time
- adapt bundle script for ?raw imports
- adjust tests and smoke test for chart rendering
- bump version to 0.5.13

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5b8ce58832f9ebfd899f4b91c4e