### PR TITLE
Fix ASAR preload verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,19 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run build:dir
+
+      - run: node scripts/verify-preload-in-asar.js dist/win-unpacked/resources/app.asar
+
       - run: npm run bundle
 
       - run: npm run build:win32
 
-      - name: Verify preload inside asar
-        shell: bash
+      - name: Verify preload in portable
+        shell: pwsh
         run: |
-          exe=$(ls dist/*.exe | head -n1)
-          npx asar list "$exe" | grep -q 'build/unpacked/renderer.bundle.js'
+          7z e -aoa (Get-ChildItem -Path dist -Filter *.exe).FullName resources/app.asar -odist/extracted
+          node scripts/verify-preload-in-asar.js dist/extracted/app.asar
 
       - uses: actions/upload-artifact@v4
         with:

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -86,5 +86,6 @@ E44 - Build Pipeline,asar check before portable,workflow split,done,CI,S,codex
 E45 - Preload Unification,portable-safe path,copy script & new workflow,done,CI,S,codex
 E46 - Preload packaging cleanup,remove copy script & unify dist folder,done,CI,S,codex,
 E47 - Preload constant,unify path constant & CI check,done,CI,S,codex,
-E48 - Bundle dir constant,align build paths in tests & CI,done,CI,S,codex
+E48 - Bundle dir constant,align build paths in tests & CI,done,CI,S,codex,
 E49 - Codex Auto Merge,PRs merged automatically,GitHub workflow,done,CI,S,codex
+E50 - Preload ASAR verify,dist preload check,test & CI,wip,CI,S,codex

--- a/__tests__/asarPreload.test.js
+++ b/__tests__/asarPreload.test.js
@@ -1,0 +1,16 @@
+const { execSync } = require('node:child_process');
+
+// ensure packaging places the preload script in app.asar
+
+test('asar contains preload', () => {
+  if (process.platform !== 'win32') return;
+  execSync('npm run bundle', { stdio: 'inherit' });
+  execSync('electron-builder --win dir', { stdio: 'inherit' });
+
+  const cmd = 'node scripts/verify-preload-in-asar.js dist/win-unpacked/resources/app.asar';
+  expect(() => execSync(cmd)).not.toThrow();
+});
+
+
+
+

--- a/scripts/verify-preload-in-asar.js
+++ b/scripts/verify-preload-in-asar.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { listPackage } = require('@electron/asar');
+const asarPath = process.argv[2];
+if (!asarPath) {
+  console.error('asar path required');
+  process.exit(1);
+}
+try {
+  const entries = listPackage(asarPath);
+  if (entries.includes('dist/preload.js')) process.exit(0);
+} catch (err) {
+  console.error(err.message);
+}
+process.exit(1);
+


### PR DESCRIPTION
## Summary
- add script to inspect app.asar
- verify unpacked and portable builds contain `dist/preload.js`
- test packaging to ensure the preload ends up inside the ASAR
- record progress in BACKLOG

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_686e8a2844ac832f851f2e6edcce67cc