### PR TITLE
Simplify portable build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,10 @@ jobs:
 
       - run: npm run build:win32
 
-      - name: Verify preload in asar
-        run: node scripts/verify-preload-in-asar.js dist/win-unpacked/resources/app.asar
+      - name: Verify preload inside portable ASAR
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path dist -Filter *.exe | Select-Object -First 1
+          if (-not $exe) { Write-Error 'portable EXE not found'; exit 1 }
+          7z e -aoa "$($exe.FullName)" 'resources/app.asar' -odist/extracted | Out-Null
+          node scripts/verify-preload-in-asar.js dist/extracted/app.asar

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -95,3 +95,4 @@ E53 - Icon build guard,dist dir check before icon build,script fix,done,CI,S,cod
 E54 - Portable verify fix,extract app-64.7z first,portable script fix,done,CI,S,codex
 E55 - Win asar check,missing build step,workflow fix,done,CI,S,codex
 E56 - Build config fix,remove stray bracket in build.ci.json,bug fixed,done,CI,S,codex
+E57 - Portable build simplification,verify single ASAR path,config & workflow updated,done,CI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.7.23 - fix: correct PowerShell asar verify command
+## v0.7.22 - fix: portable build verifies single ASAR path
 ## v0.7.21 - fix: correct build config JSON
 ## v0.7.20 - fix: run build step before asar verification
 ## v0.7.19 - fix: reliable portable ASAR extraction

--- a/build.ci.json
+++ b/build.ci.json
@@ -4,23 +4,9 @@
     "main.js",
     "assets/**"
   ],
-
+  "directories": { "output": "dist" },
   "asarUnpack": [],
-
-  "directories": {
-    "output": "dist/win-unpacked"
-  },
-
   "win": {
-    "target": [
-      { "target": "dir", "arch": ["x64"] }
-    ]
-    /*  ⚠️ Kein Signing nötig → nichts weiter angeben.
-        Wenn ihr später signieren wollt, nutzt die
-        offiziellen Optionen (`signAndEditExecutable`,
-        `cscLink`, … ) – solange ihr sie **wirklich** braucht. */
+    "target": [{ "target": "portable", "arch": ["x64"] }]
   }
-
-  /* Top-Level-Felder wie `verifyUpdateCodeSignature`
-     wurden ab v25 entfernt – deshalb hier nicht mehr aufführen. */
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.21",
+  "version": "0.7.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.7.21",
+      "version": "0.7.23",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.21",
+  "version": "0.7.23",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -8,7 +8,7 @@
     "bundle": "node scripts/make-ico.js && node scripts/bundle.js",
     "prepare-icon": "node scripts/prepare-icon.js",
     "build:dir": "electron-builder --dir --config build.ci.json",
-    "build:win32": "npm run build:dir",
+    "build:win32": "electron-builder --config build.ci.json",
     "postinstall": "node scripts/decode-icons.js && npm run prepare-icon",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "smoke": "playwright test tests/smoke/preload.test.js",


### PR DESCRIPTION
## Summary
- verify `app.asar` from the portable EXE using a corrected PowerShell command
- bump version and mark backlog entry done

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_6874ed3c9d08832fb3cd32c5f4735a0a