### PR TITLE
Fix portable build verify step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,8 @@ jobs:
 
       - run: npm run build:win32
 
-      - name: Verify preload inside portable ASAR
+      - name: Verify preload in portable
         shell: pwsh
         run: |
-          $exe = Get-ChildItem -Path dist -Filter *.exe | Select-Object -First 1
-          if (-not $exe) { Write-Error 'portable EXE not found'; exit 1 }
-          7z e -aoa "$($exe.FullName)" 'resources/app.asar' -odist/extracted | Out-Null
-          node scripts/verify-preload-in-asar.js dist/extracted/app.asar
+          pwsh scripts/verify-preload-in-portable.ps1 `
+            (Get-ChildItem -Path dist -Filter *.exe | Select-Object -First 1).FullName

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -96,3 +96,4 @@ E54 - Portable verify fix,extract app-64.7z first,portable script fix,done,CI,S,
 E55 - Win asar check,missing build step,workflow fix,done,CI,S,codex
 E56 - Build config fix,remove stray bracket in build.ci.json,bug fixed,done,CI,S,codex
 E57 - Portable build simplification,verify single ASAR path,config & workflow updated,done,CI,S,codex
+E58 - Portable verify fix,2-step extraction for asar check,bug fixed,done,CI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.7.24 - fix: verify preload with two-step portable extraction
+
 ## v0.7.23 - fix: correct PowerShell asar verify command
 ## v0.7.22 - fix: portable build verifies single ASAR path
 ## v0.7.21 - fix: correct build config JSON

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.7.23",
+      "version": "0.7.24",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "main": "main.js",
   "scripts": {
     "start": "electron .",


### PR DESCRIPTION
## Summary
- verify preload after packaging with a dedicated PS script
- bump version to 0.7.24
- document fix in CHANGELOG
- track progress in BACKLOG

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_68751875cf6c832f8ecdfcae8b404c20