### PR TITLE
Fix portable build verify step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,8 @@ jobs:
 
       - run: npm run build:win32
 
-      - name: Verify preload inside portable ASAR
+      - name: Verify preload in portable
         shell: pwsh
         run: |
-          $exe = Get-ChildItem -Path dist -Filter *.exe | Select-Object -First 1
-          if (-not $exe) { Write-Error 'portable EXE not found'; exit 1 }
-          7z e -aoa "$($exe.FullName)" 'resources/app.asar' -odist/extracted | Out-Null
-          node scripts/verify-preload-in-asar.js dist/extracted/app.asar
+          pwsh scripts/verify-preload-in-portable.ps1 `
+            (Get-ChildItem -Path dist -Filter *.exe | Select-Object -First 1).FullName

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -96,3 +96,6 @@ E54 - Portable verify fix,extract app-64.7z first,portable script fix,done,CI,S,
 E55 - Win asar check,missing build step,workflow fix,done,CI,S,codex
 E56 - Build config fix,remove stray bracket in build.ci.json,bug fixed,done,CI,S,codex
 E57 - Portable build simplification,verify single ASAR path,config & workflow updated,done,CI,S,codex
+E58 - Portable verify fix,2-step extraction for asar check,bug fixed,done,CI,S,codex
+E59 - Portable verify stable,final fix for nested app-64 archive,workflow update,done,CI,S,codex
+E60 - Portable verify fallback,handle direct & nested extraction,script update,done,CI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## v0.7.26 - fix: robust preload check for portable build
+## v0.7.25 - fix: stable preload verification in portable build
+
+## v0.7.24 - fix: verify preload with two-step portable extraction
+
 ## v0.7.23 - fix: correct PowerShell asar verify command
 ## v0.7.22 - fix: portable build verifies single ASAR path
 ## v0.7.21 - fix: correct build config JSON

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.23",
+  "version": "0.7.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.7.23",
+      "version": "0.7.26",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.23",
+  "version": "0.7.26",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/scripts/verify-preload-in-portable.ps1
+++ b/scripts/verify-preload-in-portable.ps1
@@ -8,19 +8,22 @@
 param([Parameter(Mandatory=$true)][string]$PortableExe)
 $ErrorActionPreference = 'Stop'
 
-$tmp  = 'dist\extracted'
-$tmp2 = 'dist\inner'
+
+$tmp    = 'dist\extracted'
+$tmp2   = 'dist\inner'
 Remove-Item $tmp,$tmp2 -Recurse -Force -EA SilentlyContinue
 New-Item   $tmp,$tmp2 -ItemType Directory | Out-Null
 
-# Ebene 1: app-64.7z aus dem Portable-EXE holen
-7z e -aoa "$PortableExe" 'app-64.7z' -o"$tmp" | Out-Null
+# direct extraction for modern portable builds
+7z e -aoa "$PortableExe" 'resources/app.asar' -o"$tmp" | Out-Null
 
-# Ebene 2: resources/app.asar aus app-64.7z holen
-7z e -aoa "$tmp\app-64.7z" 'resources/app.asar' -o"$tmp2" | Out-Null
-
-$asar = Join-Path $tmp2 'app.asar'
-if (-not (Test-Path $asar)) { Write-Error 'app.asar not found'; exit 1 }
+$asar = Join-Path $tmp 'app.asar'
+if (-not (Test-Path $asar)) {
+  # fallback: app-64.7z nested archive (legacy)
+  7z e -aoa "$PortableExe" 'app-64.7z' -o"$tmp2" | Out-Null
+  7z e -aoa "$tmp2\app-64.7z" 'resources/app.asar' -o"$tmp" | Out-Null
+  if (-not (Test-Path $asar)) { Write-Error 'app.asar not found'; exit 1 }
+}
 
 node scripts/verify-preload-in-asar.js $asar
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- verify preload after packaging with a resilient PowerShell script
- bump version to 0.7.26
- document fix in CHANGELOG
- track progress in BACKLOG

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_68751875cf6c832f8ecdfcae8b404c20