### PR TITLE
fix table render after csv load

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -110,3 +110,4 @@ E65 - Packaging Fix,Include runtime src in build,update build.files,done,Distrib
 E10,Build,Package renderer assets & preload guard,,done,Distribution,
 E11,UI,Help/About & Demo data now shown,,done,UX,
 E12,UX,Restore help page & fix table hiddenColumns bug,,done,UX,
+E13,Fix,Table renders after CSV load,set csvHeaders on load,done,Fix,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.7.38] – 2025-07-16
+### Fixed
+* Table renders correctly after CSV or demo import.
 ## [0.7.37] – 2025-07-15
 ### Added
 * Full help.html with user guide & changelog integration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -8,6 +8,7 @@ import Chart from 'chart.js/auto';
 import { buildChart } from '../../chartWorker.mjs';
 import './inlineEdit.js';
 import './kpi.js';
+window.__DEBUG__ = true;
 // --- test-environment stubs -------------------------------
 if (typeof window !== 'undefined' && !window.undoChange) {
   window.undoChange = () => {};
@@ -248,9 +249,17 @@ function resetFilters(){
 }
 
 function handleCsvLoaded(rows){
+  if(!csvHeaders.length && rows.length){
+    csvHeaders = Object.keys(rows[0]);
+  }
   setData(rows);
   currentPage = 1;
   resetFilters();
+  if (window.__DEBUG__) {
+    console.log('[DEBUG] rows.length', rows.length);
+    console.log('[DEBUG] first row', rows[0]);
+    console.log('[DEBUG] hiddenColumns BEFORE reset', hiddenColumns);
+  }
   hiddenColumns = [];           // Reset column visibility
   localStorage.removeItem('hiddenColumns');
   renderAll();
@@ -304,7 +313,7 @@ if(dropZone){
 // === DEMO-DATEN ===
 document.getElementById('demoDataBtn').onclick = () =>
   Papa.parse('./demo/PARTNER.csv', { download:true, header:true,
-    complete: r => { setData(r.data); currentPage=1; resetFilters(); renderAll(); }
+    complete: r => { handleCsvLoaded(r.data); }
   });
 
 eventBus.on('data:loaded', handleCsvLoaded);
@@ -463,6 +472,13 @@ function renderColumnMenu(){
 // === TABELLE + EDITOR ===
 function renderTable() {
   const data = getData();
+  if (window.__DEBUG__) {
+    console.log('[DEBUG] renderTable called with', {
+      rows: data.length,
+      hiddenColumns,
+      tableDom: document.getElementById('partnerTable')
+    });
+  }
   if (!data.length) {
     document.getElementById("partnerTable").querySelector("thead").innerHTML = "";
     document.getElementById("partnerTable").querySelector("tbody").innerHTML = "";


### PR DESCRIPTION
## Summary
- debug helpers for renderer
- reset columns and headers on CSV load
- wire demo button to `handleCsvLoaded`
- patch version to 0.7.38
- update backlog and changelog

## Testing
- `npm test`
- `npm run smoke` *(fails: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_687727c5bf04832f9adf6881c18b57ba