### PR TITLE
Fix CSV reload via menu

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -111,3 +111,4 @@ E10,Build,Package renderer assets & preload guard,,done,Distribution,
 E11,UI,Help/About & Demo data now shown,,done,UX,
 E12,UX,Restore help page & fix table hiddenColumns bug,,done,UX,
 E13,Fix,Table renders after CSV load,set csvHeaders on load,done,Fix,codex
+E13,UX,CSV reload & open-dialog fixed,,done,UX,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
-## [0.7.38] – 2025-07-16
+## [0.7.38] – 2025-07-15
 ### Fixed
-* Table renders correctly after CSV or demo import.
+* File-input resets so the same CSV can be selected multiple times.
+* Menu “CSV laden …” opens native dialog again and loads file.
 ## [0.7.37] – 2025-07-15
 ### Added
 * Full help.html with user guide & changelog integration.

--- a/__tests__/csvApiBridge.test.js
+++ b/__tests__/csvApiBridge.test.js
@@ -1,0 +1,14 @@
+jest.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: jest.fn() },
+  ipcRenderer: { invoke: jest.fn(), on: jest.fn() }
+}));
+const { contextBridge } = require('electron');
+
+ test('csvApi is exposed', async () => {
+  await import('../src/preload.js');
+  await new Promise(r => setImmediate(r));
+  const call = contextBridge.exposeInMainWorld.mock.calls.find(c => c[0] === 'csvApi');
+  expect(call).toBeTruthy();
+  expect(typeof call[1].openDialog).toBe('function');
+  expect(typeof call[1].onCsvPath).toBe('function');
+});

--- a/__tests__/renderer.init.test.js
+++ b/__tests__/renderer.init.test.js
@@ -1,4 +1,8 @@
-jest.mock('electron', () => ({__esModule: true, contextBridge: { exposeInMainWorld: jest.fn() }, default: {} }));
+jest.mock('electron', () => ({__esModule: true,
+  contextBridge: { exposeInMainWorld: jest.fn() },
+  ipcRenderer: { on: jest.fn(), invoke: jest.fn() },
+  default: {}
+}));
 const { contextBridge } = require('electron');
 jest.mock('papaparse', () => ({}));
 jest.mock('xlsx', () => ({ utils: {} }));

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -256,7 +256,7 @@ function showMsg(txt, type="success") {
 const v = window.api.version || 'dev';
 window.showVersion=()=>dialog.showMessageBox({title:'Partner-Dashboard',message:`Version ${v}`});
 
-ipcRenderer.on('open-csv-dialog', () => document.getElementById('csvFile').click());
+ipcRenderer.on('menu-open-csv', () => window.csvApi.openDialog());
 
 // === KPIs ===
 function renderKPIs() {

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@ body.dark .log-table th { background: #3a3a3a; }
       <button class="export-btn" id="demoDataBtn" style="margin-left:2rem;background:#888;">Demo-Daten laden</button>
       <button class="export-btn" id="undoBtn" style="background:#aaa;margin-left:2rem;">Undo</button>
       <button class="export-btn" id="redoBtn" style="background:#aaa;">Redo</button>
+      <button id="menuOpenCsv" style="display:none"></button>
     </div>
     <div id="msg"></div>
     <div id="liveRegion" role="status" aria-live="polite" class="hidden"></div>

--- a/src/preload.js
+++ b/src/preload.js
@@ -23,6 +23,7 @@ try {
 }
 
 const bus = mitt();
+ipcRenderer.on('menu-open-csv', () => bus.emit('menu-open-csv'));
 
 const api = {
   bus,
@@ -33,6 +34,10 @@ const api = {
 };
 
 contextBridge.exposeInMainWorld('api', api);
+contextBridge.exposeInMainWorld('csvApi', {
+  openDialog: () => ipcRenderer.invoke('dialog:openCsv'),
+  onCsvPath: cb => ipcRenderer.on('csv:path', (_, p) => cb(p))
+});
 // safe-export: nur in Node-Kontext
 if (typeof module !== 'undefined') {
   module.exports = api;

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -22,6 +22,7 @@ try {
   try { version = require('../package.json').version; } catch {} }
 
 const bus = mitt();
+ipcRenderer.on('menu-open-csv', () => bus.emit('menu-open-csv'));
 
 const api = {
   bus,
@@ -31,4 +32,8 @@ const api = {
   sendMail: opts => ipcRenderer.invoke('send-mail', opts)
 };
 contextBridge.exposeInMainWorld('api', api);
+contextBridge.exposeInMainWorld('csvApi', {
+  openDialog: () => ipcRenderer.invoke('dialog:openCsv'),
+  onCsvPath: cb => ipcRenderer.on('csv:path', (_, p) => cb(p))
+});
 module.exports = api;

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -37,6 +37,10 @@ await waitApi();
 
 const { mitt: Mitt } = window.api.libs || {};
 const eventBus = window.api.bus;
+eventBus.on('menu-open-csv', () => window.csvApi?.openDialog());
+window.csvApi?.onCsvPath?.(loadCsvFromPath);
+document.getElementById('menuOpenCsv')
+  ?.addEventListener('click', () => window.csvApi.openDialog());
 const { utils: XLSXUtils = {}, writeFile = () => {} } = XLSX;
 if(!Papa){ document.body.classList.add('no-csv'); console.error('CSV disabled'); }
 if(!Chart){ document.body.classList.add('no-chart'); console.error('Charts disabled'); }
@@ -242,6 +246,11 @@ function handleFile(file){
   reader.readAsText(file,'utf-8');
 }
 
+function loadCsvFromPath(fp){
+  if(!fp) return;
+  Papa.parse(fp, { download:true, header:true, complete:r=>handleCsvLoaded(r.data) });
+}
+
 function resetFilters(){
   document.querySelectorAll('#filters input').forEach(i=>{ i.value=''; });
   document.querySelectorAll('#partnerTable .filter-row input')
@@ -282,7 +291,12 @@ function loadCsvFile(file){
 }
 window.loadCsvFile = loadCsvFile;
 
-document.getElementById('csvFile').addEventListener('change', e => loadCsvFile(e.target.files[0]));
+document.getElementById('csvFile').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) loadCsvFromPath(file.path);
+  // allow selecting the same file again
+  e.target.value = '';
+});
 
 const dropZone = document.getElementById('dropZone');
 if(dropZone){

--- a/tests/eventBus.spec.js
+++ b/tests/eventBus.spec.js
@@ -11,7 +11,8 @@ test('eventBus module exports mitt instance', async () => {
   });
   global.window = dom.window;
   jest.mock('electron', () => ({__esModule: true,
-    contextBridge: { exposeInMainWorld: jest.fn() }
+    contextBridge: { exposeInMainWorld: jest.fn() },
+    ipcRenderer: { on: jest.fn(), invoke: jest.fn() }
   }));
   const { contextBridge } = require('electron');
   await import('../src/preload.js');


### PR DESCRIPTION
## Summary
- reset the csv file input to trigger change events again
- expose `csvApi` preload bridge and wire up menu reload
- support menu-open-csv event and native dialog loading
- hide a button for menu CSV load
- document the fix
- record backlog item
- test preload csvApi exposure

## Testing
- `npm test`
- `npm run smoke` *(fails: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_68774e60a714832fbddb6d500dd890f1