### PR TITLE
Add Steckbrief tab with basic profile view

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -112,3 +112,4 @@ E11,UI,Help/About & Demo data now shown,,done,UX,
 E12,UX,Restore help page & fix table hiddenColumns bug,,done,UX,
 E13,Fix,Table renders after CSV load,set csvHeaders on load,done,Fix,codex
 E13,UX,CSV reload & open-dialog fixed,,done,UX,
+E66 - Steckbrief Tab,360° Partneransicht,HTML + CSV Hook + Tab Logic,done,UX,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.8.0] – 2025-07-16
+### Added
+* New "Steckbrief" tab showing a basic 360° partner view.
+
 ## [0.7.38] – 2025-07-15
 ### Fixed
 * File-input resets so the same CSV can be selected multiple times.

--- a/__tests__/profileView.test.js
+++ b/__tests__/profileView.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const mitt = require('mitt');
+
+jest.mock('xlsx', () => ({ utils:{} }));
+jest.mock('chart.js/auto', () => function(){});
+
+let renderer;
+
+beforeAll(async () => {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, { url:'http://localhost', runScripts:'dangerously' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  window.HTMLCanvasElement.prototype.getContext = () => ({});
+  global.Chart = function(){};
+  window.api = { libs:{}, bus: mitt(), version:'0' };
+  await import('../src/renderer/dataStore.js');
+  renderer = await import('../src/renderer/renderer.js');
+});
+
+test('profile header fills with csv first row', () => {
+  renderer.handleCsvLoaded([{Partnername:'Foo',Partnertyp:'T',Land:'DE',Ansprechpartner_Name:'N',
+    'Ansprechpartner_E-Mail':'a@b',Telefon:'1',Rolle:'R',Score:'5'}]);
+  expect(document.getElementById('pfName').textContent).toBe('Foo');
+  expect(document.getElementById('pfMeta').textContent).toContain('T');
+  expect(document.getElementById('pfContacts').textContent).toContain('N');
+});
+
+test('profile tab toggles section visibility', () => {
+  const btn = document.querySelector('[data-tab="profileView"]');
+  btn.click();
+  expect(document.getElementById('profileView').style.display).toBe('block');
+});

--- a/index.html
+++ b/index.html
@@ -126,11 +126,25 @@ body.dark .log-table th { background: #3a3a3a; }
     <button class="tab-btn active" data-tab="overview">Übersicht</button>
     <button class="tab-btn" data-tab="table">Tabelle</button>
     <button class="tab-btn" data-tab="cards">Karten</button>
+    <button class="tab-btn" data-tab="profileView">Steckbrief</button>
     <button class="tab-btn" data-tab="charts">Diagramme</button>
     <button class="tab-btn" data-tab="changelog">Änderungsprotokoll</button>
     <button id="alertsSettingsBtn">Alerts</button>
   </nav>
   <main>
+    <section id="profileView" style="display:none">
+      <div class="header">
+        <div class="logo" style="width:60px;height:60px;background:#eee;display:inline-block;margin-right:1rem"></div>
+        <h1 id="pfName"></h1>
+        <span id="pfMeta"></span>
+        <span id="pfHealth" class="badge">-</span>
+        <button class="edit-btn">Edit</button>
+      </div>
+      <section class="card"><h3>Stammdaten</h3><ul id="pfContacts"></ul></section>
+      <section class="card"><h3>Vertragsdaten</h3><ul></ul></section>
+      <section class="card"><h3>Technik</h3><ul></ul></section>
+      <section class="card"><h3>KPIs</h3><table></table></section>
+    </section>
     <!-- Übersicht -->
     <section id="overview" class="active">
       <div style="height:140px"><canvas id="barStatus"></canvas></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.38",
+  "version": "0.8.0",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -152,18 +152,26 @@ function applyView(name){
 }
 
 // === TAB NAVIGATION ===
+const profileSection = document.getElementById('profileView');
 document.querySelectorAll('.tab-btn').forEach(btn => {
   btn.onclick = () => {
     document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
+    if(btn.dataset.tab === 'profileView'){
+      document.querySelectorAll('main section').forEach(sec => sec.style.display='none');
+      profileSection.style.display = 'block';
+      return;
+    }
+    profileSection.style.display = 'none';
     document.querySelectorAll('main section').forEach(sec => sec.classList.remove('active'));
-    document.getElementById(btn.dataset.tab).classList.add('active');
+    const sec = document.getElementById(btn.dataset.tab);
+    if(sec){ sec.classList.add('active'); }
     if (btn.dataset.tab === 'overview') renderOverview();
     if (btn.dataset.tab === 'table') renderTable();
     if (btn.dataset.tab === 'cards') renderCards();
     if (btn.dataset.tab === 'charts') renderCharts();
     if (btn.dataset.tab === 'changelog') renderChangelog();
-  }
+  };
 });
 
 // === CSV IMPORT & PARSE ===
@@ -268,6 +276,17 @@ function handleCsvLoaded(rows){
     console.log('[DEBUG] rows.length', rows.length);
     console.log('[DEBUG] first row', rows[0]);
     console.log('[DEBUG] hiddenColumns BEFORE reset', hiddenColumns);
+  }
+  if(rows[0]){
+    const r = rows[0];
+    document.getElementById('pfName').textContent = r['Partnername'] || '';
+    document.getElementById('pfMeta').textContent = `${r['Partnertyp']||''} · ${r['Land']||''}`;
+    document.getElementById('pfHealth').textContent = r['Score']||'-';
+    document.getElementById('pfContacts').innerHTML = `
+      <li>${r['Ansprechpartner_Name']||'-'}</li>
+      <li>${r['Ansprechpartner_E-Mail']||'-'}</li>
+      <li>${r['Telefon']||'-'}</li>
+      <li>${r['Rolle']||'-'}</li>`;
   }
   hiddenColumns = [];           // Reset column visibility
   localStorage.removeItem('hiddenColumns');

--- a/styles.css
+++ b/styles.css
@@ -8,3 +8,5 @@ th,td{white-space:nowrap;padding:0.6rem 0.8rem;border:1px solid #e0e0e0;max-widt
 .kpi{flex:1 1 120px;min-width:120px}
 @media (max-width:1000px){.kpi{padding:.8rem 1.2rem;font-size:.9rem}}
 body.no-chart [data-tab="charts"] { pointer-events:none; opacity:.4; }
+.badge{border-radius:9999px;padding:2px 8px;font-weight:600}
+.card{border:1px solid #ddd;margin:1rem 0;padding:1rem}


### PR DESCRIPTION
## Summary
- implement Steckbrief profile section in HTML
- style .badge and .card via stylesheet
- populate Steckbrief info after CSV load
- extend tab logic to toggle profile view
- add unit tests for profile header and tab visibility
- document change in CHANGELOG and backlog
- bump version to 0.8.0

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_68776c2c5520832f9581479935d48b50