### PR TITLE
Fix profile tab and add partner dropdown

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -113,3 +113,4 @@ E12,UX,Restore help page & fix table hiddenColumns bug,,done,UX,
 E13,Fix,Table renders after CSV load,set csvHeaders on load,done,Fix,codex
 E13,UX,CSV reload & open-dialog fixed,,done,UX,
 E66 - Steckbrief Tab,360° Partneransicht,HTML + CSV Hook + Tab Logic,done,UX,S,codex
+E67 - Steckbrief Integration,Tab-Refactor & Mock Daten,view classes|dropdown|placeholders,done,UX,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.8.1] – 2025-07-17
+### Fixed
+* Tab switching keeps other views visible and profile dropdown selects partners.
+
 ## [0.8.0] – 2025-07-16
 ### Added
 * New "Steckbrief" tab showing a basic 360° partner view.

--- a/__tests__/profileView.test.js
+++ b/__tests__/profileView.test.js
@@ -21,16 +21,27 @@ beforeAll(async () => {
   renderer = await import('../src/renderer/renderer.js');
 });
 
-test('profile header fills with csv first row', () => {
-  renderer.handleCsvLoaded([{Partnername:'Foo',Partnertyp:'T',Land:'DE',Ansprechpartner_Name:'N',
-    'Ansprechpartner_E-Mail':'a@b',Telefon:'1',Rolle:'R',Score:'5'}]);
+test('profile header fills with csv first row and dropdown', () => {
+  renderer.handleCsvLoaded([
+    {Partnername:'Foo',Partnertyp:'T',Land:'DE',Ansprechpartner_Name:'N','Ansprechpartner_E-Mail':'a@b'},
+    {Partnername:'Bar',Partnertyp:'X',Land:'US',Ansprechpartner_Name:'Z','Ansprechpartner_E-Mail':'c@d'}
+  ]);
   expect(document.getElementById('pfName').textContent).toBe('Foo');
   expect(document.getElementById('pfMeta').textContent).toContain('T');
-  expect(document.getElementById('pfContacts').textContent).toContain('N');
+  const options = document.querySelectorAll('#partnerSelect option');
+  expect(options.length).toBe(2);
+});
+
+test('profile dropdown switches partner', () => {
+  const select = document.getElementById('partnerSelect');
+  select.value = '1';
+  select.dispatchEvent(new window.Event('change'));
+  expect(document.getElementById('pfName').textContent).toBe('Bar');
 });
 
 test('profile tab toggles section visibility', () => {
   const btn = document.querySelector('[data-tab="profileView"]');
   btn.click();
-  expect(document.getElementById('profileView').style.display).toBe('block');
+  expect(document.getElementById('profileView').classList.contains('hidden')).toBe(false);
+  expect(document.getElementById('overview').classList.contains('hidden')).toBe(true);
 });

--- a/index.html
+++ b/index.html
@@ -132,21 +132,22 @@ body.dark .log-table th { background: #3a3a3a; }
     <button id="alertsSettingsBtn">Alerts</button>
   </nav>
   <main>
-    <section id="profileView" style="display:none">
+    <section id="profileView" class="view hidden">
       <div class="header">
         <div class="logo" style="width:60px;height:60px;background:#eee;display:inline-block;margin-right:1rem"></div>
+        <select id="partnerSelect"></select>
         <h1 id="pfName"></h1>
         <span id="pfMeta"></span>
         <span id="pfHealth" class="badge">-</span>
         <button class="edit-btn">Edit</button>
       </div>
       <section class="card"><h3>Stammdaten</h3><ul id="pfContacts"></ul></section>
-      <section class="card"><h3>Vertragsdaten</h3><ul></ul></section>
-      <section class="card"><h3>Technik</h3><ul></ul></section>
-      <section class="card"><h3>KPIs</h3><table></table></section>
+      <div class="card placeholder">– Vertragsdaten folgen –</div>
+      <div class="card placeholder">– Finanzdaten folgen –</div>
+      <div class="card placeholder">– Tickets-Block folgt –</div>
     </section>
     <!-- Übersicht -->
-    <section id="overview" class="active">
+    <section id="overview" class="view">
       <div style="height:140px"><canvas id="barStatus"></canvas></div>
       <div class="kpi-boxes" id="kpiBoxes"></div>
       <div id="dropZone" class="drop-zone">CSV hierher ziehen <span id="dropStatus"></span></div>
@@ -156,7 +157,7 @@ body.dark .log-table th { background: #3a3a3a; }
       </div>
     </section>
     <!-- Tabelle -->
-    <section id="table">
+    <section id="table" class="view hidden">
       <div class="search-filter" id="filters"></div>
       <div style="position:relative;margin-bottom:.5rem;">
         <select id="viewSelect" style="margin-right:.5rem;">
@@ -179,14 +180,14 @@ body.dark .log-table th { background: #3a3a3a; }
       <div id="pagination" style="margin-top:.5rem;"><button id="prevPage" class="export-btn" style="background:#777;margin-right:.5rem;">Prev</button><span id="pageInfo"></span><button id="nextPage" class="export-btn" style="background:#777;margin-left:.5rem;">Next</button></div>
     </section>
     <!-- Kartenansicht -->
-    <section id="cards">
+    <section id="cards" class="view hidden">
       <div class="search-filter">
         <input type="text" id="cardSearchInput" placeholder="Suche Partner...">
       </div>
       <div class="cards" id="partnerCards"></div>
     </section>
     <!-- Chart-Tab -->
-    <section id="charts">
+    <section id="charts" class="view hidden">
       <div style="display:flex;flex-wrap:wrap;gap:2rem;">
         <div class="chart-box">
           <h3>Vertragstypen (Pie)</h3>
@@ -207,7 +208,7 @@ body.dark .log-table th { background: #3a3a3a; }
       </div>
     </section>
     <!-- Änderungsprotokoll -->
-    <section id="changelog">
+    <section id="changelog" class="view hidden">
       <h3>Änderungsprotokoll</h3>
       <table class="log-table" id="changelogTable">
         <thead>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.35",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.7.35",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/styles.css
+++ b/styles.css
@@ -10,3 +10,6 @@ th,td{white-space:nowrap;padding:0.6rem 0.8rem;border:1px solid #e0e0e0;max-widt
 body.no-chart [data-tab="charts"] { pointer-events:none; opacity:.4; }
 .badge{border-radius:9999px;padding:2px 8px;font-weight:600}
 .card{border:1px solid #ddd;margin:1rem 0;padding:1rem}
+.placeholder{color:#666;background:#f7f7f7;font-style:italic}
+.view.hidden{display:none}
+.view.active{display:block}


### PR DESCRIPTION
## Summary
- keep non-profile views visible by toggling a `hidden` class
- populate partner dropdown and render selected row
- add placeholder cards for contract, finance, and tickets
- regression tests for profile dropdown
- document new Steckbrief integration

## Testing
- `npm test`
- `npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_6877719f0c7c832fa4c876f94614b74f