### PR TITLE
Fix DOM IDs after tab rename

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -114,3 +114,4 @@ E13,Fix,Table renders after CSV load,set csvHeaders on load,done,Fix,codex
 E13,UX,CSV reload & open-dialog fixed,,done,UX,
 E66 - Steckbrief Tab,360° Partneransicht,HTML + CSV Hook + Tab Logic,done,UX,S,codex
 E67 - Steckbrief Integration,Tab-Refactor & Mock Daten,view classes|dropdown|placeholders,done,UX,S,codex
+E68 - DOM ID Align,IDs after tab rename,renderer & HTML fix,done,Fix,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.7.40] – 2025-07-17
+### Fixed
+* fix: align DOM IDs after tab rename (table renders).
 ## [0.8.1] – 2025-07-17
 ### Fixed
 * Tab switching keeps other views visible and profile dropdown selects partners.

--- a/__tests__/profileView.test.js
+++ b/__tests__/profileView.test.js
@@ -43,5 +43,5 @@ test('profile tab toggles section visibility', () => {
   const btn = document.querySelector('[data-tab="profileView"]');
   btn.click();
   expect(document.getElementById('profileView').classList.contains('hidden')).toBe(false);
-  expect(document.getElementById('overview').classList.contains('hidden')).toBe(true);
+  expect(document.getElementById('overviewView').classList.contains('hidden')).toBe(true);
 });

--- a/index.html
+++ b/index.html
@@ -123,11 +123,11 @@ body.dark .log-table th { background: #3a3a3a; }
     <div id="liveRegion" role="status" aria-live="polite" class="hidden"></div>
   </header>
   <nav>
-    <button class="tab-btn active" data-tab="overview">Übersicht</button>
-    <button class="tab-btn" data-tab="table">Tabelle</button>
-    <button class="tab-btn" data-tab="cards">Karten</button>
+    <button class="tab-btn active" data-tab="overviewView">Übersicht</button>
+    <button class="tab-btn" data-tab="tableView">Tabelle</button>
+    <button class="tab-btn" data-tab="mapView">Karten</button>
     <button class="tab-btn" data-tab="profileView">Steckbrief</button>
-    <button class="tab-btn" data-tab="charts">Diagramme</button>
+    <button class="tab-btn" data-tab="chartView">Diagramme</button>
     <button class="tab-btn" data-tab="changelog">Änderungsprotokoll</button>
     <button id="alertsSettingsBtn">Alerts</button>
   </nav>
@@ -147,7 +147,7 @@ body.dark .log-table th { background: #3a3a3a; }
       <div class="card placeholder">– Tickets-Block folgt –</div>
     </section>
     <!-- Übersicht -->
-    <section id="overview" class="view">
+    <section id="overviewView" class="view">
       <div style="height:140px"><canvas id="barStatus"></canvas></div>
       <div class="kpi-boxes" id="kpiBoxes"></div>
       <div id="dropZone" class="drop-zone">CSV hierher ziehen <span id="dropStatus"></span></div>
@@ -157,7 +157,7 @@ body.dark .log-table th { background: #3a3a3a; }
       </div>
     </section>
     <!-- Tabelle -->
-    <section id="table" class="view hidden">
+    <section id="tableView" class="view hidden">
       <div class="search-filter" id="filters"></div>
       <div style="position:relative;margin-bottom:.5rem;">
         <select id="viewSelect" style="margin-right:.5rem;">
@@ -180,14 +180,14 @@ body.dark .log-table th { background: #3a3a3a; }
       <div id="pagination" style="margin-top:.5rem;"><button id="prevPage" class="export-btn" style="background:#777;margin-right:.5rem;">Prev</button><span id="pageInfo"></span><button id="nextPage" class="export-btn" style="background:#777;margin-left:.5rem;">Next</button></div>
     </section>
     <!-- Kartenansicht -->
-    <section id="cards" class="view hidden">
+    <section id="mapView" class="view hidden">
       <div class="search-filter">
         <input type="text" id="cardSearchInput" placeholder="Suche Partner...">
       </div>
       <div class="cards" id="partnerCards"></div>
     </section>
     <!-- Chart-Tab -->
-    <section id="charts" class="view hidden">
+    <section id="chartView" class="view hidden">
       <div style="display:flex;flex-wrap:wrap;gap:2rem;">
         <div class="chart-box">
           <h3>Vertragstypen (Pie)</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.8.0",
+  "version": "0.7.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.8.0",
+      "version": "0.7.40",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.8.1",
+  "version": "0.7.40",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -49,6 +49,15 @@ if(demoBtn && !Papa) demoBtn.disabled = true;
 const I18N={
   de:{demoBtn:"Demo-Daten laden"}
 }; // TODO(Epic-9)
+const tabMap = {
+  Dashboard: 'overview',
+  Partner: 'table',
+  Karten: 'map',
+  Analytics: 'chart',
+  '360° Steckbrief': 'profile',
+  Verlauf: 'history',
+  Alerts: 'alerts'
+};
 // TODO(Epic-8): Onboarding docs
 // TODO(Epic-10): Portable build tweaks
 // === GLOBAL DATA STRUCTURES ===
@@ -154,8 +163,9 @@ function applyView(name){
 
 // === TAB NAVIGATION ===
 function switchTab(tabName){
+  const id = tabMap[tabName] ? `${tabMap[tabName]}View` : tabName;
   document.querySelectorAll('.view').forEach(v=>v.classList.add('hidden'));
-  const el = document.getElementById(tabName);
+  const el = document.getElementById(id);
   if(el) el.classList.remove('hidden');
 }
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -163,11 +173,12 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
     document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     switchTab(btn.dataset.tab);
-    if (btn.dataset.tab === 'overview') renderOverview();
-    if (btn.dataset.tab === 'table') renderTable();
-    if (btn.dataset.tab === 'cards') renderCards();
-    if (btn.dataset.tab === 'charts') renderCharts();
-    if (btn.dataset.tab === 'changelog') renderChangelog();
+    const name = btn.dataset.tab;
+    if (name === 'overviewView' || name === 'Dashboard') renderOverview();
+    if (name === 'tableView' || name === 'Partner') renderTable();
+    if (name === 'mapView' || name === 'Karten') renderCards();
+    if (name === 'chartView' || name === 'Analytics') renderCharts();
+    if (name === 'changelog' || name === 'Verlauf') renderChangelog();
   };
 });
 


### PR DESCRIPTION
## Summary
- update version to 0.7.40
- align view IDs and tab switching logic
- keep table id `partnerTable`
- update profileView test
- document fix in changelog and backlog

## Testing
- `npm test`
- `npm run smoke` *(fails: electron launch error)*

------
https://chatgpt.com/codex/tasks/task_e_687779dd7194832f894dcd0dd8459efd