### PR TITLE
Add smoke test for wizard state

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -128,3 +128,4 @@ E70 - Quick Fix,Wizard & Steckbrief layout,cleanup open/close + tiles modal,done
 E71 - Quick Fix,Wizard & Steckbrief bug-sprint,fixed autostart & layout,done,Fix,S,codex
 E72 - Bug,Wizard öffnet beim Start,Autostart abschalten,done,Fix,S,codex
 E73 - Bugfix,Remove wizard autostart triggers,tests + production guard,done,Fix,S,codex
+E74 - Test,Wizard closed at launch,Playwright smoke,done,Quality,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.7.56] – 2025-07-17
+### Added
+* Playwright smoke test ensures wizard stays closed on launch
+
 ## [0.7.55] – 2025-07-21
 ### Fixed
 * wizard hidden on startup; open only via button

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.55",
+  "version": "0.7.56",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -11,7 +11,7 @@
     "build:win32": "cross-env NODE_ENV=production electron-builder",
     "postinstall": "node scripts/decode-icons.js && npm run prepare-icon",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
-    "smoke": "playwright test tests/smoke/preload.test.js",
+    "smoke": "playwright test tests/smoke",
     "ci": "npm run lint && npm run bundle && npm test && npm run build:win32",
     "postversion": "npm run bundle"
   },

--- a/tests/smoke/wizardClosed.test.js
+++ b/tests/smoke/wizardClosed.test.js
@@ -1,0 +1,11 @@
+const { test, expect } = require('@playwright/test');
+const { _electron: electron } = require('playwright');
+
+// Ensure wizard stays closed on startup
+test('wizard remains closed on launch', async () => {
+  const app = await electron.launch({ args: ['.', '--no-sandbox'], env:{ ELECTRON_DISABLE_SANDBOX:'1' } });
+  await app.waitForEvent('ipc', (_e, msg) => msg === 'app-loaded');
+  const page = await app.firstWindow();
+  await expect(page.locator('#wizardModal')).toBeHidden();
+  await app.close();
+}, 30_000);


### PR DESCRIPTION
## Summary
- add Playwright smoke test verifying the wizard stays closed on launch
- run smoke tests from the whole folder
- bump version to 0.7.56
- document new test in CHANGELOG
- track progress in BACKLOG

## Testing
- `npm test`
- `npm run smoke` *(fails: electron could not launch)*

------
https://chatgpt.com/codex/tasks/task_e_6878f620fb70832fbdda22bdcba83fde