### PR TITLE
Fix e2e launch test setup

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -131,3 +131,5 @@ E73 - Bugfix,Remove wizard autostart triggers,tests + production guard,done,Fix,
 E74 - Test,Wizard closed at launch,Playwright smoke,done,Quality,S,codex
 E75 - Test,Wizard start e2e,ensure hidden on launch,done,Quality,S,codex
 E76 - CI Fix,Wizard e2e config,Playwright config & workflow,done,CI,S,codex
+E77 - CI Fix,Wizard e2e stable,explicit main script + bundle,done,CI,S,codex
+E78 - CI Fix,Wizard e2e headless,main path corrected,done,CI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [0.7.60] – 2025-07-24
+### Fixed
+* correct Electron main script path for e2e test; pass sandbox flags
+## [0.7.59] – 2025-07-24
+### Fixed
+* e2e wizard test builds bundle and launches explicit main script
+
 ## [0.7.58] – 2025-07-23
 ### Fixed
 * stable wizard start smoke test in CI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.55",
+  "version": "0.7.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "partner-dashboard-clean",
-      "version": "0.7.55",
+      "version": "0.7.60",
       "hasInstallScript": true,
       "dependencies": {
         "chart.js": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.58",
+  "version": "0.7.60",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -14,7 +14,7 @@
     "smoke": "playwright test tests/smoke",
     "ci": "npm run lint && npm run bundle && npm test && npm run build:win32",
     "postversion": "npm run bundle",
-    "e2e": "playwright test"
+    "e2e": "npx playwright test tests/e2e"
   },
   "devDependencies": {
     "@electron/asar": "^3.2.14",

--- a/tests/e2e/wizard-start.spec.ts
+++ b/tests/e2e/wizard-start.spec.ts
@@ -1,8 +1,17 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
 import { test, expect, _electron as electron } from '@playwright/test';
 
 test('wizard hidden on fresh launch', async () => {
-  // 1. Electron-App starten (Main-Entry = ".")
-  const app = await electron.launch({ args: ['.'] });
+  // Build renderer bundle before launching Electron
+  execSync('npm run bundle', { stdio: 'inherit' });
+
+  // 1. Electron-App starten (Main-Entry = "main.js")
+  const app = await electron.launch({
+    executablePath: require('electron'),
+    args: [path.join(__dirname, '../../main.js'), '--no-sandbox'],
+    env: { ELECTRON_DISABLE_SANDBOX: '1' },
+  });
 
   // 2. Erstes Renderer-Fenster holen
   const page = await app.firstWindow();


### PR DESCRIPTION
## Summary
- build app before running electron in e2e test
- launch electron with explicit main.js and sandbox flags
- bump version to 0.7.60
- document fix and backlog entry

## Testing
- `npm test`
- `npm run smoke`
- `npx playwright test tests/e2e/wizard-start.spec.ts` *(fails: Missing X server or DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68791b458528832f9bb38fa1c60b54bf