### PR TITLE
Fix e2e launch via Xvfb in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
         run: node scripts/lint-no-bare-imports.js
       - name: Run unit tests
         run: npm test
+      - name: Install Xvfb
+        run: sudo apt-get update -qq && sudo apt-get install -y xvfb
+      - name: Start virtual display
+        run: |
+          Xvfb :99 -screen 0 1920x1080x24 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
       - name: Run Smoke-E2E
         run: npm run e2e
 

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -133,3 +133,4 @@ E75 - Test,Wizard start e2e,ensure hidden on launch,done,Quality,S,codex
 E76 - CI Fix,Wizard e2e config,Playwright config & workflow,done,CI,S,codex
 E77 - CI Fix,Wizard e2e stable,explicit main script + bundle,done,CI,S,codex
 E78 - CI Fix,Wizard e2e headless,main path corrected,done,CI,S,codex
+E79 - CI Fix,Wizard e2e Xvfb,Ubuntu job sets up virtual display,done,CI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.7.61] – 2025-07-24
+### Fixed
+* CI runs E2E tests under Xvfb
 ## [0.7.60] – 2025-07-24
 ### Fixed
 * correct Electron main script path for e2e test; pass sandbox flags

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.60",
+  "version": "0.7.61",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -14,7 +14,7 @@
     "smoke": "playwright test tests/smoke",
     "ci": "npm run lint && npm run bundle && npm test && npm run build:win32",
     "postversion": "npm run bundle",
-    "e2e": "npx playwright test tests/e2e"
+    "e2e": "npm run bundle && playwright test tests/e2e"
   },
   "devDependencies": {
     "@electron/asar": "^3.2.14",


### PR DESCRIPTION
## Summary
- set up Xvfb display for Playwright Electron tests on Ubuntu runners
- ensure bundle is built before running e2e tests
- bump version to 0.7.61
- track CI fix in backlog

## Testing
- `npm test`
- `npm run smoke` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68792eb8139c832f8fa1f0b1612d04ce