### PR TITLE
Add header clock

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -148,3 +148,4 @@ E87 - Preload contract fix,Preload contract fix,window.api.version() again,done,
 E88 - Bugfix,Wizard stays closed,manual open only,done,Fix,S,codex
 E89 - Bugfix,Canvas stub via globalSetup,Playwright smoke fix,done,Fix,S,codex
 E90 - Bugfix,Expose version string & wizard manual open,smoke suite green,in progress,Fix,S,codex
+E91 - UX,Digital Clock,show time in header,done,UI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.77] – 2025-07-24
+### Added
+* digital clock in dashboard header
+
 ## [0.7.76] – 2025-07-24
 ### Fixed
 * preload exposes version string

--- a/__tests__/digitalClock.test.js
+++ b/__tests__/digitalClock.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const mitt = require('mitt');
+jest.mock('chart.js/auto', () => function(){});
+
+beforeAll(async () => {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    url: 'http://localhost',
+    runScripts: 'dangerously',
+    beforeParse(window) {
+      window.api = { libs: {}, bus: mitt(), version: () => '0' };
+      window.Chart = function(){};
+    }
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  window.HTMLCanvasElement.prototype.getContext = () => ({ });
+});
+
+test('digital clock is rendered', () => {
+  const clock = document.getElementById('clock');
+  expect(clock).not.toBeNull();
+  expect(clock.textContent).toMatch(/\d{2}:\d{2}/);
+});

--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@ body.dark .log-table th { background: #3a3a3a; }
 <body>
   <header>
   <h1 id="appTitle">Partner-Dashboard <small id="appVersion"></small></h1>
+  <div id="clock"></div>
     <button id="darkModeToggle" class="export-btn" style="background:#555;margin-left:1rem;">Dark Mode</button>
     <div class="file-upload">
       <input type="file" id="csvFile" accept=".csv" />
@@ -285,6 +286,12 @@ body.dark .log-table th { background: #3a3a3a; }
         ? window.api.version()
         : window.api.version;
     document.getElementById('appVersion').textContent = v;
+    function updateClock(){
+      const el = document.getElementById('clock');
+      if(el) el.textContent = new Date().toLocaleTimeString();
+    }
+    updateClock();
+    setInterval(updateClock, 1000);
   </script>
   <script type="module" defer src="build/unpacked/renderer.bundle.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.76",
+  "version": "0.7.77",
   "main": "main.js",
   "scripts": {
     "start": "electron .",


### PR DESCRIPTION
## Summary
- show a digital clock in the dashboard header
- record feature in BACKLOG
- bump version to 0.7.77 and document change
- add Playwright-style test for clock element

## Testing
- `npm run dev:verify`

------
https://chatgpt.com/codex/tasks/task_e_687a4457ab80832faaa69c1aa341ae92