### PR TITLE
feat: contract sprint (preload + ipc + stub)

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -149,3 +149,4 @@ E88 - Bugfix,Wizard stays closed,manual open only,done,Fix,S,codex
 E89 - Bugfix,Canvas stub via globalSetup,Playwright smoke fix,done,Fix,S,codex
 E90 - Bugfix,Expose version string & wizard manual open,smoke suite green,done,Fix,S,codex
 E91 - UX,Digital Clock,show time in header,done,UI,S,codex
+E92 - Automation,V-Spec 1.0,preload version+ipc app-loaded,done,Fix,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.80] – 2025-07-18
+### Added
+* contract sprint: preload version API and app-loaded IPC
+
 ## [0.7.79] – 2025-07-18
 ### Fixed
 * stable app-loaded IPC on window ready

--- a/dist/preload.js
+++ b/dist/preload.js
@@ -1,11 +1,14 @@
 const { contextBridge, ipcRenderer } = require("electron");
 const mitt = require("mitt");
 const { version: pkgVersion } = require("../package.json");
-let version = pkgVersion;
+let ver = pkgVersion;
 try {
   const dist = require("../dist/version.json");
-  if (dist && dist.version) version = dist.version;
+  if (dist && dist.version) ver = dist.version;
 } catch (e) {
+}
+if (process.env.DEBUG === "smoke") {
+  console.log(`[smoke] version ${ver}`);
 }
 function safeRequire(name) {
   try {
@@ -24,8 +27,8 @@ ipcRenderer.on("menu-open-csv", () => bus.emit("menu-open-csv"));
 const api = {
   bus,
   libs,
-  version,
-  versionFn: () => version,
+  version: ver,
+  versionFn: () => ver,
   onAppLoaded: (cb) => ipcRenderer.on("app-loaded", cb),
   sendMail: (opts) => ipcRenderer.invoke("send-mail", opts)
 };

--- a/main.js
+++ b/main.js
@@ -108,6 +108,7 @@ function createWindow() {
   mainWindow.webContents.once('did-finish-load', () => {
     mainWindow.webContents.send('app-loaded');
     if (process.send) process.send('app-loaded');
+    ipcMain.emit('app-loaded');
   });
   createMenu(mainWindow);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.77",
+  "version": "0.7.80",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -11,7 +11,8 @@
     "build:win32": "cross-env NODE_ENV=production electron-builder",
     "postinstall": "node scripts/decode-icons.js && npm run prepare-icon",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
-    "smoke": "playwright test -c playwright.smoke.config.ts",
+    "pre-smoke": "npm run bundle",
+    "smoke": "cross-env DEBUG=smoke playwright test -c playwright.smoke.config.ts",
     "ci": "npm run lint && npm run bundle && npm test && npm run build:win32",
     "postversion": "npm run bundle",
     "e2e": "playwright test tests/e2e",

--- a/preload.js
+++ b/preload.js
@@ -1,11 +1,14 @@
 const { contextBridge, ipcRenderer } = require("electron");
 const mitt = require("mitt");
 const { version: pkgVersion } = require("../package.json");
-let version = pkgVersion;
+let ver = pkgVersion;
 try {
   const dist = require("../dist/version.json");
-  if (dist && dist.version) version = dist.version;
+  if (dist && dist.version) ver = dist.version;
 } catch (e) {
+}
+if (process.env.DEBUG === "smoke") {
+  console.log(`[smoke] version ${ver}`);
 }
 function safeRequire(name) {
   try {
@@ -24,8 +27,8 @@ ipcRenderer.on("menu-open-csv", () => bus.emit("menu-open-csv"));
 const api = {
   bus,
   libs,
-  version,
-  versionFn: () => version,
+  version: ver,
+  versionFn: () => ver,
   onAppLoaded: (cb) => ipcRenderer.on("app-loaded", cb),
   sendMail: (opts) => ipcRenderer.invoke("send-mail", opts)
 };

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,14 +1,17 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const mitt = require('mitt');
 const { version: pkgVersion } = require('../package.json');
-let version = pkgVersion;
+let ver = pkgVersion;
 try {
   // override with bundled version if available
   // eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
   const dist = require('../dist/version.json');
-  if (dist && dist.version) version = dist.version;
+  if (dist && dist.version) ver = dist.version;
 } catch (e) {
   // ignore - use package.json version
+}
+if (process.env.DEBUG === 'smoke') {
+  console.log(`[smoke] version ${ver}`);
 }
 
 function safeRequire(name) {
@@ -31,8 +34,8 @@ ipcRenderer.on('menu-open-csv', () => bus.emit('menu-open-csv'));
 const api = {
   bus,
   libs,
-  version,
-  versionFn: () => version,
+  version: ver,
+  versionFn: () => ver,
   onAppLoaded: (cb) => ipcRenderer.on('app-loaded', cb),
   sendMail: (opts) => ipcRenderer.invoke('send-mail', opts),
 };


### PR DESCRIPTION
## Summary
- expose version from `dist/version.json` in preload
- emit `app-loaded` on BrowserWindow ready
- ensure canvas stub via Playwright global setup
- bundle automatically before smoke test and set DEBUG flag
- bump patch version

## Testing
- `npm run dev:verify`
- `xvfb-run -a npm run smoke` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_687a4a690188832facac2e9899296269