### PR TITLE
Implement pipeline and preload fixes

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -150,3 +150,4 @@ E89 - Bugfix,Canvas stub via globalSetup,Playwright smoke fix,done,Fix,S,codex
 E90 - Bugfix,Expose version string & wizard manual open,smoke suite green,done,Fix,S,codex
 E91 - UX,Digital Clock,show time in header,done,UI,S,codex
 E92 - Automation,V-Spec 1.0,preload version+ipc app-loaded,done,Fix,S,codex
+E93 - Automation,Pipeline fix,bundle before smoke; freeze api,getVersion,done,Fix,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.81] – 2025-07-18
+### Fixed
+* preload contract frozen (getVersion) and bundler runs before smoke
+
 ## [0.7.80] – 2025-07-18
 ### Added
 * contract sprint: preload version API and app-loaded IPC

--- a/__tests__/appLoaded.once.test.js
+++ b/__tests__/appLoaded.once.test.js
@@ -1,0 +1,43 @@
+jest.mock('electron', () => {
+  const { EventEmitter } = require('events');
+  const send = jest.fn();
+  let lastWindow;
+  class WebContents extends EventEmitter {
+    send = send;
+  }
+  class BrowserWindow {
+    constructor() {
+      this.webContents = new WebContents();
+      lastWindow = this;
+    }
+    loadFile() {
+      setImmediate(() => this.webContents.emit('did-finish-load'));
+    }
+    setMenu() {}
+  }
+  const ipcMain = new EventEmitter();
+  ipcMain.handle = jest.fn();
+  return {
+    app: { getVersion: () => '0.0.0', whenReady: () => Promise.resolve(), on: jest.fn() },
+    BrowserWindow,
+    Menu: { setApplicationMenu: jest.fn(), buildFromTemplate: t => t },
+    shell: {}, dialog: {}, ipcMain,
+    __mockedSend: send,
+    __lastWindow: () => lastWindow
+  };
+});
+
+const { ipcMain, __mockedSend: send, __lastWindow } = require('electron');
+
+describe('app-loaded IPC', () => {
+  test('emitted once after did-finish-load', async () => {
+    const { createWindow } = require('../main.js');
+    createWindow();
+    const win = __lastWindow();
+    let count = 0;
+    ipcMain.on('app-loaded', () => { count += 1; });
+    win.webContents.emit('did-finish-load');
+    expect(send).toHaveBeenCalledWith('app-loaded');
+    expect(count).toBe(1);
+  });
+});

--- a/__tests__/globalSetup.bundle.test.js
+++ b/__tests__/globalSetup.bundle.test.js
@@ -1,0 +1,9 @@
+const { execFileSync } = require('node:child_process');
+jest.mock('node:child_process', () => ({ execFileSync: jest.fn() }));
+
+const setup = require('../tests/globalSetup.js');
+
+test('globalSetup bundles before smoke', async () => {
+  await setup();
+  expect(execFileSync).toHaveBeenCalledWith('npm', ['run', 'bundle'], expect.any(Object));
+});

--- a/__tests__/preload.version.test.js
+++ b/__tests__/preload.version.test.js
@@ -7,5 +7,5 @@ const api = require('../src/preload.js');
 test('version exposiert String und Funktion', () => {
   expect(typeof api.version).toBe('string');
   expect(api.version).toMatch(/^\d+\.\d+\.\d+$/);
-  expect(api.versionFn()).toBe(api.version);
+  expect(api.getVersion()).toBe(api.version);
 });

--- a/__tests__/version.api.test.js
+++ b/__tests__/version.api.test.js
@@ -12,5 +12,5 @@ test('version exposed as string and fn', () => {
   window.api = api;
   expect(typeof window.api.version).toBe('string');
   expect(window.api.version).toMatch(/^\d+\.\d+\.\d+$/);
-  expect(window.api.versionFn()).toBe(window.api.version);
+  expect(window.api.getVersion()).toBe(window.api.version);
 });

--- a/dist/preload.js
+++ b/dist/preload.js
@@ -24,14 +24,14 @@ const libs = {
 };
 const bus = mitt();
 ipcRenderer.on("menu-open-csv", () => bus.emit("menu-open-csv"));
-const api = {
+const api = Object.freeze({
   bus,
   libs,
   version: ver,
-  versionFn: () => ver,
+  getVersion: () => ver,
   onAppLoaded: (cb) => ipcRenderer.on("app-loaded", cb),
   sendMail: (opts) => ipcRenderer.invoke("send-mail", opts)
-};
+});
 contextBridge.exposeInMainWorld("api", api);
 contextBridge.exposeInMainWorld("csvApi", {
   openDialog: () => ipcRenderer.invoke("dialog:openCsv"),

--- a/main.js
+++ b/main.js
@@ -128,7 +128,7 @@ if (require.main === module) {
   });
 }
 
-module.exports = { getMenuTemplate, createMenu };
+module.exports = { getMenuTemplate, createMenu, createWindow };
 
 // test helpers
 let _rows = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.80",
+  "version": "0.7.81",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,3 +1,4 @@
+import './tests/_canvasStub.js';
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/preload.js
+++ b/preload.js
@@ -24,14 +24,14 @@ const libs = {
 };
 const bus = mitt();
 ipcRenderer.on("menu-open-csv", () => bus.emit("menu-open-csv"));
-const api = {
+const api = Object.freeze({
   bus,
   libs,
   version: ver,
-  versionFn: () => ver,
+  getVersion: () => ver,
   onAppLoaded: (cb) => ipcRenderer.on("app-loaded", cb),
   sendMail: (opts) => ipcRenderer.invoke("send-mail", opts)
-};
+});
 contextBridge.exposeInMainWorld("api", api);
 contextBridge.exposeInMainWorld("csvApi", {
   openDialog: () => ipcRenderer.invoke("dialog:openCsv"),

--- a/src/preload.js
+++ b/src/preload.js
@@ -31,14 +31,14 @@ const libs = {
 const bus = mitt();
 ipcRenderer.on('menu-open-csv', () => bus.emit('menu-open-csv'));
 
-const api = {
+const api = Object.freeze({
   bus,
   libs,
   version: ver,
-  versionFn: () => ver,
+  getVersion: () => ver,
   onAppLoaded: (cb) => ipcRenderer.on('app-loaded', cb),
   sendMail: (opts) => ipcRenderer.invoke('send-mail', opts),
-};
+});
 
 contextBridge.exposeInMainWorld('api', api);
 contextBridge.exposeInMainWorld('csvApi', {

--- a/tests/_canvasStub.js
+++ b/tests/_canvasStub.js
@@ -1,0 +1,5 @@
+// Global canvas stub for Playwright smoke tests
+class DummyCanvas {}
+if (!global.window) global.window = {};
+global.HTMLCanvasElement = DummyCanvas;
+global.window.HTMLCanvasElement = DummyCanvas;

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -1,10 +1,5 @@
+const { execFileSync } = require('node:child_process');
+
 module.exports = async () => {
-  // provide a dummy canvas element for chart.js
-  class DummyCanvas {}
-  // Node globals
-  global.HTMLCanvasElement = DummyCanvas;
-  // provide a minimal window object if missing
-  if (!global.window) global.window = {};
-  global.window.HTMLCanvasElement = DummyCanvas;
-  // no return value needed
+  execFileSync('npm', ['run', 'bundle'], { stdio: 'inherit' });
 };


### PR DESCRIPTION
## Summary
- run bundler inside smoke global setup
- freeze preload API and expose `getVersion`
- export `createWindow` and emit `app-loaded` once
- ensure canvas stub loads first for smoke tests
- add unit tests for bundling and app-loaded event
- bump version to 0.7.81

## Testing
- `npm run dev:verify`

------
https://chatgpt.com/codex/tasks/task_e_687a50bcdb1c832fa80a9df790e2b19d