### PR TITLE
Fix preload path and backlog hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 grep -R "import .*['A-Za-z']" src/renderer && \
   echo "❌  Renderer enthält bare-Import" && exit 1 || true
+node scripts/check-backlog.js

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -152,3 +152,4 @@ E91 - UX,Digital Clock,show time in header,done,UI,S,codex
 E92 - Automation,V-Spec 1.0,preload version+ipc app-loaded,done,Fix,S,codex
 E93 - Automation,Pipeline fix,bundle before smoke; freeze api getVersion,done,Fix,S,codex
 E94 - Automation,Logging instrumentation,opt-in debug logs,done,Infra,S,codex
+F1 - Automation,Preload path check,dist preload path + backlog columns hook,done,Fix,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.7.83] – 2025-07-18
+### Fixed
+* preload path uses dist/preload.js with debug log
+* pre-commit enforces BACKLOG columns
+
 ## [0.7.82] – 2025-07-18
 ### Fixed
 * added opt-in debug logs

--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -42,4 +42,20 @@ describe('debug logger', () => {
     const txt = fs.readFileSync(logPath, 'utf8');
     expect(txt.includes('emitting app-loaded')).toBe(true);
   });
+
+  test('logs preload missing when file absent', () => {
+    process.env.LOG_LEVEL = 'debug';
+    try { fs.unlinkSync(logPath); } catch {}
+    const exists = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.isolateModules(() => {
+      jest.doMock('electron-log', () => ({
+        info: jest.fn(),
+        transports: { file: { level: 'debug', resolvePathFn: jest.fn() }, console: { level: 'debug' } }
+      }));
+      const log = require('electron-log');
+      require('../main.js');
+      expect(log.info).toHaveBeenCalledWith('[pl-dbg] preload missing', expect.any(String));
+    });
+    exists.mockRestore();
+  });
 });

--- a/main.js
+++ b/main.js
@@ -6,7 +6,8 @@ const log = require('electron-log');
 log.transports.file.level = process.env.LOG_LEVEL || 'error';
 log.transports.console.level = log.transports.file.level;
 log.transports.file.resolvePathFn = () => path.join(__dirname, 'logs/main.log');
-const PRELOAD = path.join(__dirname, 'preload.js');
+const PRELOAD = path.join(__dirname, 'dist', 'preload.js');
+if (!fs.existsSync(PRELOAD)) log.info('[pl-dbg] preload missing', PRELOAD);
 let mainWindow;
 // works in dev (npm start) and in the packed ASAR
 const nodemailer = require('nodemailer');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.82",
+  "version": "0.7.83",
   "main": "main.js",
   "scripts": {
     "start": "electron .",


### PR DESCRIPTION
## Summary
- ensure main process resolves dist/preload.js
- add debug log if preload missing
- enforce BACKLOG structure in pre-commit
- update unit tests
- document patch in CHANGELOG and BACKLOG
- bump version to 0.7.83

## Testing
- `npm test`
- `npm run dev:verify`


------
https://chatgpt.com/codex/tasks/task_e_687a5857c924832f82110293ba60bba1