### PR TITLE
Patch preload resolution and backlog checks

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -153,3 +153,5 @@ E92 - Automation,V-Spec 1.0,preload version+ipc app-loaded,done,Fix,S,codex
 E93 - Automation,Pipeline fix,bundle before smoke; freeze api getVersion,done,Fix,S,codex
 E94 - Automation,Logging instrumentation,opt-in debug logs,done,Infra,S,codex
 F1 - Automation,Preload path check,dist preload path + backlog columns hook,done,Fix,S,codex
+F2 - Automation,Smoke-test guard,fail clearly when window.api missing,done,Fix,S,codex
+F3 - Automation,Dev-verify backlog check,fail when BACKLOG columns ≠ 7,done,Fix,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.7.84] – 2025-07-18
+### Fixed
+* preload path resolves dist/preload.js when present
+* smoke test checks window.api existence
+* dev-verify ensures BACKLOG columns
+
 ## [0.7.83] – 2025-07-18
 ### Fixed
 * preload path uses dist/preload.js with debug log

--- a/__tests__/resolvePreloadPath.test.js
+++ b/__tests__/resolvePreloadPath.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const resolvePreloadPath = require('../src/main/resolvePreloadPath');
+
+test('prefers dist/preload.js when present', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pl-'));
+  fs.mkdirSync(path.join(dir, 'dist'));
+  const distPath = path.join(dir, 'dist', 'preload.js');
+  const fallback = path.join(dir, 'preload.js');
+  fs.writeFileSync(distPath, '');
+  fs.writeFileSync(fallback, '');
+  expect(resolvePreloadPath(dir)).toBe(distPath);
+});
+
+test('falls back to preload.js when dist missing', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pl-'));
+  const fallback = path.join(dir, 'preload.js');
+  fs.writeFileSync(fallback, '');
+  expect(resolvePreloadPath(dir)).toBe(fallback);
+});

--- a/main.js
+++ b/main.js
@@ -6,7 +6,8 @@ const log = require('electron-log');
 log.transports.file.level = process.env.LOG_LEVEL || 'error';
 log.transports.console.level = log.transports.file.level;
 log.transports.file.resolvePathFn = () => path.join(__dirname, 'logs/main.log');
-const PRELOAD = path.join(__dirname, 'dist', 'preload.js');
+const resolvePreloadPath = require("./src/main/resolvePreloadPath");
+const PRELOAD = resolvePreloadPath(__dirname);
 if (!fs.existsSync(PRELOAD)) log.info('[pl-dbg] preload missing', PRELOAD);
 let mainWindow;
 // works in dev (npm start) and in the packed ASAR

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.83",
+  "version": "0.7.84",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/scripts/dev-verify.sh
+++ b/scripts/dev-verify.sh
@@ -7,6 +7,9 @@ npm ci
 echo "[dev-verify] lint"
 npm run lint
 
+echo "[dev-verify] backlog columns"
+node scripts/check-backlog.js
+
 echo "[dev-verify] jest unit"
 npm test
 

--- a/src/main/resolvePreloadPath.js
+++ b/src/main/resolvePreloadPath.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+function resolvePreloadPath(baseDir) {
+  const dist = path.join(baseDir, 'dist', 'preload.js');
+  if (fs.existsSync(dist)) return dist;
+  return path.join(baseDir, 'preload.js');
+}
+
+module.exports = resolvePreloadPath;

--- a/tests/smoke/preload.test.js
+++ b/tests/smoke/preload.test.js
@@ -16,6 +16,8 @@ test('App exposes version and renders charts', async () => {
   const page = await app.firstWindow();
   captureConsole(page);
   await page.waitForSelector('body');
+  const hasApi = await page.evaluate(() => typeof window.api !== 'undefined');
+  expect(hasApi).toBe(true);
   const res = await page.evaluate(() => ({
     version: typeof window.api.version === 'function'
              ? window.api.version()


### PR DESCRIPTION
## Summary
- add resolvePreloadPath helper
- fallback to local preload.js when dist/preload.js missing
- guard smoke test for missing window.api
- verify backlog.csv column count in dev:verify
- document changes and bump version

## Testing
- `npm run lint`
- `npm test`
- `xvfb-run -a npm run smoke` *(fails: Unable to load preload script)*
- `npm run dev:verify` *(fails: 2 smoke tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687a5cda0e90832fbc72e8efe3db7c38