### PR TITLE
Bundle diagnostics and stable exit

### DIFF
--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -165,3 +165,4 @@ T25 - Sprint2,Contract Doc,update AGENTS preload section,done,Docs,S,codex
 T26 - Sprint3,Preload Hardening,new readiness API,done,Infra,S,codex
 T27 - Sprint3,Smoke Fix,stabilize preload readiness,done,Infra,S,codex
 T28 - Sprint3,Phase1 Stabilisierung,base-ui/charts readiness + app-loaded IPC + Smoke Grün,done,Infra,S,codex
+T29 - Sprint3,Bundle Diagnostik,bundle.js instrumentation,done,Infra,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.93] – 2025-07-19
+### Fixed
+* bundle diagnostics and stable exit code
+
 ## [0.7.92] – 2025-07-19
 ### Fixed
 * Restored app-loaded IPC and added base-ui / charts readiness flags; smoke tests stabilized

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/scripts/bundle-preload.js
+++ b/scripts/bundle-preload.js
@@ -4,16 +4,21 @@ const fs = require('fs');
 const { version } = require('../package.json');
 
 fs.mkdirSync('dist', { recursive: true });
+const entry = fs.existsSync('src/preload/index.cjs') ? 'src/preload/index.cjs' : 'src/preload/index.js';
 
-esbuild.build({
-  entryPoints: ['src/preload/index.js'],
-  bundle: true,
-  platform: 'browser',
-  format: 'iife',
-  target: ['chrome115'],
-  external: ['electron'],
-  define: { APP_VERSION: JSON.stringify(version) },
-  outfile: 'dist/preload.js',
-  minify: false,
-  logLevel: 'info'
-}).catch(() => process.exit(1));
+(async () => {
+  await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    platform: 'browser',
+    format: 'iife',
+    target: 'es2020',
+    define: {
+      'process.env.APP_VERSION': JSON.stringify(version),
+      APP_VERSION: JSON.stringify(version)
+    },
+    outfile: 'dist/preload.js',
+    minify: true,
+    logLevel: 'info'
+  });
+})();

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -1,28 +1,111 @@
 #!/usr/bin/env node
+const path = require('node:path');
+const fs = require('node:fs');
 const esbuild = require('esbuild');
 const importGlob = require('esbuild-plugin-import-glob').default;
-const fs = require('fs');
-const path = require('path');
-const { version } = require('../package.json');
 
-fs.mkdirSync('build/unpacked', { recursive: true });
+const DEBUG = /^(debug|trace)$/.test(process.env.LOG_LEVEL || '');
 
-esbuild.build({
-  entryPoints: ['src/renderer/renderer.js'],
-  bundle: true,
-  minify: true,
-  treeShaking: true,
-  outfile: 'build/unpacked/renderer.bundle.js',
-  format: 'esm',
-  target: ['es2022'],
-  define: { 'process.env.NODE_ENV': '"production"' },
-  external: ['electron'],
-  plugins: [importGlob()],
-  sourcemap: true,
-  logLevel: 'info'
-}).then(() => {
-  fs.writeFileSync('build/unpacked/version.json', JSON.stringify({ version }, null, 2) + '\n');
-  fs.writeFileSync('dist/version.json', JSON.stringify({ version }, null, 2) + '\n');
-  if (!fs.existsSync('main.js')) fs.copyFileSync('src/main.js', 'main.js');
-  console.log('[bundle] wrote build files');
-}).catch(() => process.exit(1));
+function log(...a){ if (DEBUG) console.log('[bundle]', ...a); }
+function warn(...a){ console.warn('[bundle:warn]', ...a); }
+function err(...a){ console.error('[bundle:error]', ...a); }
+
+process.on('unhandledRejection', r => {
+  console.error('[bundle:unhandledRejection]', r);
+  process.exitCode = 1;
+});
+process.on('uncaughtException', e => {
+  console.error('[bundle:uncaughtException]', e);
+  process.exitCode = 1;
+});
+
+console.time('[bundle:total]');
+(async () => {
+  log('start');
+
+  let version = '0.0.0';
+  try {
+    const pkg = require('../package.json');
+    if (pkg && pkg.version) version = pkg.version;
+    log('package version', version);
+  } catch(e) {
+    warn('could not read package.json version – using fallback', e.message);
+  }
+
+  fs.mkdirSync('build/unpacked', { recursive: true });
+  log('invoking esbuild.render');
+  const buildResult = await esbuild.build({
+    entryPoints: ['src/renderer/renderer.js'],
+    bundle: true,
+    minify: true,
+    treeShaking: true,
+    outfile: 'build/unpacked/renderer.bundle.js',
+    format: 'esm',
+    target: ['es2022'],
+    define: {
+      'process.env.APP_VERSION': JSON.stringify(version),
+      APP_VERSION: JSON.stringify(version),
+      ...(process.env.NODE_ENV === 'production' ? { 'process.env.NODE_ENV': '"production"' } : {})
+    },
+    external: ['electron'],
+    plugins: [importGlob()],
+    sourcemap: true,
+    logLevel: 'silent'
+  });
+
+  if (buildResult.warnings?.length) {
+    warn(`esbuild warnings: ${buildResult.warnings.length}`);
+    if (DEBUG) buildResult.warnings.forEach(w => warn(w));
+  }
+  log('renderer build ok');
+
+  if (!fs.existsSync(path.join(__dirname, 'bundle-preload.js'))) {
+    log('building preload inline');
+    const preloadEntry = fs.existsSync('src/preload/index.cjs')
+      ? 'src/preload/index.cjs'
+      : (fs.existsSync('src/preload/index.js') ? 'src/preload/index.js' : null);
+    if (!preloadEntry) {
+      warn('no preload entry found, skipping preload build');
+    } else {
+      const preloadResult = await esbuild.build({
+        entryPoints: [preloadEntry],
+        bundle: true,
+        platform: 'browser',
+        format: 'iife',
+        target: 'es2020',
+        outfile: 'dist/preload.js',
+        banner: { js: '// generated preload bundle' },
+        define: {
+          'process.env.APP_VERSION': JSON.stringify(version),
+          APP_VERSION: JSON.stringify(version)
+        },
+        minify: true,
+        logLevel: 'silent'
+      });
+      if (preloadResult.warnings?.length) warn(`preload warnings: ${preloadResult.warnings.length}`);
+      log('preload build ok');
+    }
+  } else {
+    log('skipping inline preload – external script present');
+  }
+
+  try {
+    fs.mkdirSync('dist', { recursive: true });
+    fs.writeFileSync('dist/version.json', JSON.stringify({ version }, null, 2));
+    fs.mkdirSync('build/unpacked', { recursive: true });
+    fs.writeFileSync('build/unpacked/version.json', JSON.stringify({ version }, null, 2));
+    if (!fs.existsSync('main.js')) fs.copyFileSync('src/main.js', 'main.js');
+    log('wrote dist/version.json');
+  } catch(e) {
+    warn('failed to write dist/version.json', e.message);
+  }
+
+  console.log('  build/unpacked/renderer.bundle.js      (done)');
+  log('before success marker');
+  console.timeEnd('[bundle:total]');
+  if (process.exitCode && process.exitCode !== 0) {
+    err('Process had recorded exitCode != 0 earlier – preserving.');
+    process.exit(process.exitCode);
+  }
+  process.exit(0);
+})();


### PR DESCRIPTION
## Summary
- instrument `scripts/bundle.js` for better diagnostics and stable exit codes
- update preload bundler to inject version constants
- bump version to 0.7.93
- log entry for the change
- record backlog progress

## Testing
- `npm run bundle:all`
- `npm test`
- `npm run dev:verify`

------
https://chatgpt.com/codex/tasks/task_e_687b9cec14a8832fbe9f938e2dea2550