### PR TITLE
Add bundle verification script with CI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,10 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
       - run: npm ci --cache ~/npm-cache --prefer-offline
       - run: node scripts/check-backlog.js
-      - run: npm run bundle
+      - name: Bundle
+        run: LOG_LEVEL=debug npm run bundle:all | tee bundle.log
+      - name: Verify bundle artifacts
+        run: BUNDLE_LOG_PATH=bundle.log node scripts/verify-bundle.js
       - name: Upload dist
         uses: actions/upload-artifact@v4
         with:
@@ -53,7 +56,10 @@ jobs:
           echo "DISPLAY=:99" >> $GITHUB_ENV
       - run: npm ci --cache ~/npm-cache --prefer-offline
       - run: npm test
-      - run: npm run bundle
+      - name: Bundle
+        run: LOG_LEVEL=debug npm run bundle:all | tee bundle.log
+      - name: Verify bundle artifacts
+        run: BUNDLE_LOG_PATH=bundle.log node scripts/verify-bundle.js
       - name: Run Smoke
         run: LOG_LEVEL=debug npm run smoke
         env:
@@ -84,7 +90,10 @@ jobs:
         with:
           name: renderer-dist
           path: dist/
-      - run: npm run bundle
+      - name: Bundle
+        run: LOG_LEVEL=debug npm run bundle:all | tee bundle.log
+      - name: Verify bundle artifacts
+        run: BUNDLE_LOG_PATH=bundle.log node scripts/verify-bundle.js
       - run: npm run build:win32
       - name: Upload portable EXE
         uses: actions/upload-artifact@v4

--- a/BACKLOG.csv
+++ b/BACKLOG.csv
@@ -166,3 +166,4 @@ T26 - Sprint3,Preload Hardening,new readiness API,done,Infra,S,codex
 T27 - Sprint3,Smoke Fix,stabilize preload readiness,done,Infra,S,codex
 T28 - Sprint3,Phase1 Stabilisierung,base-ui/charts readiness + app-loaded IPC + Smoke Grün,done,Infra,S,codex
 T29 - Sprint3,Bundle Diagnostik,bundle.js instrumentation,done,Infra,S,codex
+E95 - Monitoring,Bundle Monitoring,verify script & workflow step,done,CI,S,codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.94] – 2025-07-19
+### Internal
+* Added bundle verification script (scripts/verify-bundle.js) to enforce artifact integrity
+
 ## [0.7.93] – 2025-07-19
 ### Fixed
 * bundle diagnostics and stable exit code

--- a/__tests__/verify-bundle.cli.test.js
+++ b/__tests__/verify-bundle.cli.test.js
@@ -1,0 +1,46 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+
+const script = 'scripts/verify-bundle.js';
+
+function setupSuccessEnv() {
+  fs.rmSync('build', { recursive: true, force: true });
+  fs.rmSync('dist', { recursive: true, force: true });
+  fs.mkdirSync('build/unpacked', { recursive: true });
+  fs.mkdirSync('dist', { recursive: true });
+  fs.writeFileSync('build/unpacked/renderer.bundle.js', 'x'.repeat(60 * 1024));
+  fs.writeFileSync('dist/preload.js', 'x'.repeat(2048));
+  fs.writeFileSync('dist/version.json', JSON.stringify({ version: '1.2.3' }));
+  fs.writeFileSync('log.txt', '[bundle:success] renderer.bundle.js written');
+}
+
+test('verify-bundle fails when artifacts missing', () => {
+  fs.rmSync('build', { recursive: true, force: true });
+  fs.rmSync('dist', { recursive: true, force: true });
+  const res = spawnSync('node', [script], { encoding: 'utf8' });
+  expect(res.status).toBe(1);
+  const out = JSON.parse(res.stdout.trim());
+  expect(out.reason).toBe('missing-artifact');
+});
+
+test('verify-bundle succeeds with valid artifacts and marker', () => {
+  setupSuccessEnv();
+  const res = spawnSync('node', [script], {
+    env: { ...process.env, BUNDLE_LOG_PATH: 'log.txt' },
+    encoding: 'utf8'
+  });
+  expect(res.status).toBe(0);
+  expect(res.stdout).toContain('[verify] ok');
+});
+
+test('verify-bundle fails when success marker missing', () => {
+  setupSuccessEnv();
+  fs.writeFileSync('log.txt', 'no marker');
+  const res = spawnSync('node', [script], {
+    env: { ...process.env, BUNDLE_LOG_PATH: 'log.txt' },
+    encoding: 'utf8'
+  });
+  expect(res.status).toBe(1);
+  const out = JSON.parse(res.stdout.trim());
+  expect(out.reason).toBe('missing-success-marker');
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partner-dashboard-clean",
-  "version": "0.7.93",
+  "version": "0.7.94",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -103,6 +103,7 @@ console.time('[bundle:total]');
   console.log('  build/unpacked/renderer.bundle.js      (done)');
   log('before success marker');
   console.timeEnd('[bundle:total]');
+  console.log('[bundle:success] renderer.bundle.js written');
   if (process.exitCode && process.exitCode !== 0) {
     err('Process had recorded exitCode != 0 earlier – preserving.');
     process.exit(process.exitCode);

--- a/scripts/verify-bundle.js
+++ b/scripts/verify-bundle.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_LEVEL = process.env.LOG_LEVEL || '';
+const DEBUG = /debug/.test(LOG_LEVEL);
+
+function debug(...a) { if (DEBUG) console.log('[verify:debug]', ...a); }
+function info(msg) { console.log('[verify]', msg); }
+function warn(msg) { console.warn('[verify:warn]', msg); }
+function fail(reason, details = {}) {
+  console.log(JSON.stringify({ status: 'fail', reason, ...details }));
+  process.exit(1);
+}
+
+function checkFile(file, minSize) {
+  if (!fs.existsSync(file)) fail('missing-artifact', { file });
+  const { size } = fs.statSync(file);
+  if (size < minSize) fail('artifact-too-small', { file, size });
+  return size;
+}
+
+const rendererPath = path.join('build', 'unpacked', 'renderer.bundle.js');
+const preloadPath = path.join('dist', 'preload.js');
+const versionPath = path.join('dist', 'version.json');
+const SUCCESS_MARKER = '[bundle:success] renderer.bundle.js written';
+
+let rendererSize;
+let preloadSize;
+let version;
+
+try {
+  rendererSize = checkFile(rendererPath, 50 * 1024);
+  preloadSize = checkFile(preloadPath, 1 * 1024);
+} catch (e) {
+  // fail() already handled exit
+  process.exit(1);
+}
+
+try {
+  const data = fs.readFileSync(versionPath, 'utf8');
+  const json = JSON.parse(data);
+  version = json.version;
+  if (!/^\d+\.\d+\.\d+$/.test(version)) fail('invalid-version', { version });
+} catch (e) {
+  fail('version-parse-fail');
+}
+
+function getLogPath() {
+  if (process.env.BUNDLE_LOG_PATH && fs.existsSync(process.env.BUNDLE_LOG_PATH)) {
+    return process.env.BUNDLE_LOG_PATH;
+  }
+  const alt = path.join('scripts', 'bundle.log');
+  if (fs.existsSync(alt)) return alt;
+  return null;
+}
+
+function checkSuccessMarker() {
+  const logPath = getLogPath();
+  if (!logPath) { warn('no bundle log, skipping success marker'); return; }
+  debug('checking', logPath);
+  const logContent = fs.readFileSync(logPath, 'utf8');
+  if (!logContent.includes(SUCCESS_MARKER)) {
+    fail('missing-success-marker', { log: logPath });
+  }
+}
+
+checkSuccessMarker();
+
+info(`ok renderer:${rendererSize}B preload:${preloadSize}B version:${version}`);
+


### PR DESCRIPTION
## Summary
- add `scripts/verify-bundle.js` to check build artifacts
- output success marker from bundler
- verify bundles in CI workflow steps
- add tests for verify script
- log new task in BACKLOG and update changelog
- bump version to 0.7.94

## Testing
- `npm run dev:verify`

------
https://chatgpt.com/codex/tasks/task_e_687ba284c820832f997b80a93bfd2f1d